### PR TITLE
feat(flows): loop primitive + quote admin fan-out + quote_pdf

### DIFF
--- a/src/modules/quotes/services/QuotesService.ts
+++ b/src/modules/quotes/services/QuotesService.ts
@@ -371,61 +371,32 @@ export class QuotesService {
 
     if (error) throw error;
 
-    if (data.status === 'accepted') {
-      flowEventService.emit('quote_approved', {
-        quote_id: quote.id,
-        user_id: quote.user_id,
-      });
-      // Notify workspace admins
+    if (data.status === 'accepted' || data.status === 'rejected') {
+      // Admin fan-out is delivered by the "Quote Accepted/Rejected → Notify
+      // Admins" flow (Loop over admin_ids → Create Notification). The event
+      // carries the admin recipient list + payload so an admin can pause/edit it.
+      const accepted = data.status === 'accepted';
+      const eventName = accepted ? 'quote_approved' : 'quote_rejected';
+      const quoteRef = quote.quote_number || quote.id.slice(0, 8);
+      const emitQuoteEvent = (adminIds: string[]) =>
+        flowEventService.emit(eventName, {
+          quote_id: quote.id,
+          user_id: quote.user_id,
+          admin_ids: adminIds,
+          type: accepted ? 'quote_accepted' : 'quote_rejected',
+          title: accepted ? `Quote ${quoteRef} accepted` : `Quote ${quoteRef} declined`,
+          body: accepted ? 'A client has accepted the quote.' : 'A client has declined the quote.',
+          action_url: `/admin/quotes/${quote.id}`,
+        });
       if (quote.workspace_id) {
         supabase
           .from('workspace_members')
           .select('user_id')
           .eq('workspace_id', quote.workspace_id)
           .in('role', ADMIN_ROLES)
-          .then(({ data: admins }) => {
-            if (admins?.length) {
-              supabase.from('user_notifications').insert(
-                admins.map((m) => ({
-                  user_id: m.user_id,
-                  type: 'quote_accepted',
-                  title: `Quote ${quote.quote_number || quote.id.slice(0, 8)} accepted`,
-                  body: 'A client has accepted the quote.',
-                  action_url: `/admin/quotes/${quote.id}`,
-                  is_read: false,
-                  metadata: { quote_id: quote.id },
-                })),
-              ).then(() => {});
-            }
-          });
-      }
-    } else if (data.status === 'rejected') {
-      flowEventService.emit('quote_rejected', {
-        quote_id: quote.id,
-        user_id: quote.user_id,
-      });
-      // Notify workspace admins
-      if (quote.workspace_id) {
-        supabase
-          .from('workspace_members')
-          .select('user_id')
-          .eq('workspace_id', quote.workspace_id)
-          .in('role', ADMIN_ROLES)
-          .then(({ data: admins }) => {
-            if (admins?.length) {
-              supabase.from('user_notifications').insert(
-                admins.map((m) => ({
-                  user_id: m.user_id,
-                  type: 'quote_rejected',
-                  title: `Quote ${quote.quote_number || quote.id.slice(0, 8)} declined`,
-                  body: 'A client has declined the quote.',
-                  action_url: `/admin/quotes/${quote.id}`,
-                  is_read: false,
-                  metadata: { quote_id: quote.id },
-                })),
-              ).then(() => {});
-            }
-          });
+          .then(({ data: admins }) => emitQuoteEvent((admins || []).map((m) => m.user_id)));
+      } else {
+        emitQuoteEvent([]);
       }
     }
 

--- a/supabase/functions/flow-engine/index.ts
+++ b/supabase/functions/flow-engine/index.ts
@@ -954,6 +954,52 @@ async function executeFlowGraph(
 
       if (node.type === 'triggerNode') {
         output = { ...triggerData };
+      } else if (node.type === 'conditionNode' && node.data.conditionType === 'loop') {
+        // Fan-out: run the directly-connected downstream action node(s) once per
+        // item in a collection. config: { collection_field: 'trigger.data.items',
+        // item_variable: 'item', max_iterations: 100 }. Single-level body (direct
+        // action children); each iteration exposes context[item_variable] +
+        // context.loop_index, so an action can template {{item}} or {{item.field}}.
+        const loopCfg = node.data.config as {
+          collection_field?: string;
+          item_variable?: string;
+          max_iterations?: number;
+        };
+        const loopPath = String(loopCfg.collection_field || '').replace(/\{\{|\}\}/g, '').trim();
+        const loopRaw = getNestedValue(context as unknown as Record<string, unknown>, loopPath);
+        const hardCap = Math.min(Number(loopCfg.max_iterations) || 100, 1000);
+        const loopItems = Array.isArray(loopRaw) ? loopRaw.slice(0, hardCap) : [];
+        const itemVar = loopCfg.item_variable || 'item';
+        const loopChildIds = edges.filter((e) => e.source === nodeId).map((e) => e.target);
+
+        for (let i = 0; i < loopItems.length; i++) {
+          (context as Record<string, unknown>)[itemVar] = loopItems[i];
+          (context as Record<string, unknown>).loop_index = i;
+          for (const cid of loopChildIds) {
+            const child = nodes.find((n) => n.id === cid);
+            if (!child || child.type !== 'actionNode') continue;
+            const iterStart = Date.now();
+            const res = await executeAction(supabase, child, context, isTestRun, userId);
+            await supabase.from('flow_run_steps').insert({
+              flow_run_id: runId,
+              node_id: child.id,
+              node_type: 'action',
+              node_label: `${child.data.label} [#${i}]`,
+              node_config: child.data.config,
+              status: 'completed',
+              output_data: res.output,
+              execution_order: executionOrder++,
+              started_at: new Date(iterStart).toISOString(),
+              completed_at: new Date().toISOString(),
+              duration_ms: Date.now() - iterStart,
+            });
+          }
+        }
+        delete (context as Record<string, unknown>)[itemVar];
+        delete (context as Record<string, unknown>).loop_index;
+        // Children ran inline — mark visited so the BFS doesn't re-run them.
+        for (const cid of loopChildIds) visited.add(cid);
+        output = { looped: true, item_count: loopItems.length };
       } else if (node.type === 'conditionNode') {
         const result = await executeCondition(node, context);
         output = result.output;

--- a/supabase/functions/generate-quote-pdf/index.ts
+++ b/supabase/functions/generate-quote-pdf/index.ts
@@ -5,6 +5,7 @@ import { fetchQuoteData, fetchTemplateConfig, fetchStorageFile } from './data-fe
 import { buildQuotePDF } from './pdf-builder.ts';
 import type { QuotePDFRequest, QuotePDFResponse } from './types.ts';
 import { withApiLogging } from '../_shared/api-logger.ts';
+import { emitFlowEvent } from '../_shared/flow-events.ts';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
 const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
@@ -149,15 +150,14 @@ Deno.serve(withApiLogging('generate-quote-pdf', async (req) => {
       .eq('id', quoteId)
       .single();
     if (quoteRecord?.user_id) {
-      supabase.from('user_notifications').insert({
+      emitFlowEvent('quote_pdf_generated', {
         user_id: quoteRecord.user_id,
         type: 'pdf_ready',
         title: 'Your quote PDF is ready',
         body: `Quote ${quoteData.quote_number || ''} PDF has been generated and is ready to download.`,
         action_url: `/quotes/${quoteId}`,
-        is_read: false,
-        metadata: { quote_id: quoteId },
-      }).then(() => {});
+        quote_id: quoteId,
+      }).catch(() => {});
     }
 
     const response: QuotePDFResponse = {

--- a/supabase/functions/stripe-webhooks/index.ts
+++ b/supabase/functions/stripe-webhooks/index.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import Stripe from 'https://esm.sh/stripe@14.10.0';
 import { bootstrapForFunction } from '../_shared/secrets-bootstrap.ts';
+import { emitFlowEvent } from '../_shared/flow-events.ts';
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
 const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';

--- a/supabase/functions/stripe-webhooks/index.ts
+++ b/supabase/functions/stripe-webhooks/index.ts
@@ -246,15 +246,17 @@ async function handlePaymentSucceeded(paymentIntent: Stripe.PaymentIntent) {
       console.error('Error granting credits:', error);
     } else {
       console.log(`Granted ${creditAmount} credits to user ${profile.user_id}`);
-      supabase.from('user_notifications').insert({
+      // Credits are granted above (must stay in the webhook). The notification
+      // is delivered by the "Payment Succeeded" flow (Flows dashboard).
+      emitFlowEvent('stripe_payment_succeeded', {
         user_id: profile.user_id,
         type: 'payment_success',
         title: 'Credits added to your account',
         body: `${creditAmount} credits have been added to your account.`,
         action_url: '/settings/billing',
-        is_read: false,
-        metadata: { credit_amount: parseFloat(creditAmount), payment_intent_id: paymentIntent.id },
-      }).then(() => {});
+        credit_amount: parseFloat(creditAmount),
+        payment_intent_id: paymentIntent.id,
+      }).catch(() => {});
     }
   }
 }
@@ -359,15 +361,15 @@ async function handlePaymentFailed(paymentIntent: Stripe.PaymentIntent) {
 
   if (!profile) return;
 
-  supabase.from('user_notifications').insert({
+  // Delivered by the "Payment Failed" flow (Flows dashboard).
+  emitFlowEvent('stripe_payment_failed', {
     user_id: profile.user_id,
     type: 'payment_failed',
     title: 'Payment failed',
     body: 'Your payment could not be processed. Please update your payment details.',
     action_url: '/settings/billing',
-    is_read: false,
-    metadata: { payment_intent_id: paymentIntent.id },
-  }).then(() => {});
+    payment_intent_id: paymentIntent.id,
+  }).catch(() => {});
 }
 
 async function handleInvoicePaid(invoice: Stripe.Invoice) {


### PR DESCRIPTION
## What this adds

Builds the deferred **`loop` primitive** and converts the events that were previously blocked by uncommitted WIP (now committed).

### Engine
- Implements the `loop` condition in the flow-engine graph walker. Config `{ collection_field, item_variable, max_iterations }`: resolves the collection from context and runs the directly-connected downstream action node(s) once per item, exposing `context[item_variable]` + `context.loop_index` (action templates `{{item}}` / `{{item.field}}`). Single-level body, hard cap 1000. The loop palette node, ConditionNode label, and ConditionConfigForm case already existed ? this fills in the missing engine execution.

### Conversions
- **Quote admin fan-out** (`quote_approved` / `quote_rejected`): emit the admin recipient list (`admin_ids`) + payload instead of a batch insert. Delivered by seeded "Quote Accepted/Rejected -> Notify Admins" flows (Loop over `admin_ids` -> Create Notification) ? the loop's first live consumer.
- **`quote_pdf_generated`** (generate-quote-pdf): emit instead of direct insert.
- **`stripe_payment_succeeded` / `stripe_payment_failed`** (stripe-webhooks): emit the notification; the credit grant stays in the webhook.

7 new active default flows seeded (`system-default`), 2 of them loop-based. Frontend typechecks clean.

## Deferred follow-ups (each needs an engine extension or explicit go-ahead)
- stripe `invoice_paid` notification ? needs a new `invoice_paid` trigger type.
- Finance statement email ? needs `send_email` attachment support (PDF statement).
- Email channel for role-upgrade/factory ? needs `send_email` template-variables support (bell channel already on flows).
- Python monitoring bridge (price/mention/job) + `debit_credits` action ? audit-deprioritized; touches paid-alert delivery.

?? Generated with [Claude Code](https://claude.com/claude-code)
