### PR TITLE
feat(flows): governance - lock-delete + System Areas registry + docs

### DIFF
--- a/docs/flows-notification-system.md
+++ b/docs/flows-notification-system.md
@@ -1,0 +1,232 @@
+# Flows — Notification & Automation System
+
+_Last updated: 2026-05-31_
+
+This document is the single reference for how platform notifications/emails are
+delivered through the **Flows** engine, how events map to flows, and how the
+governance layer (locking + System Areas) keeps coverage from silently breaking.
+
+---
+
+## 1. What this is
+
+Historically, every "send a notification / email" action was hardcoded at its
+call site (a direct `user_notifications` insert or an `email-api` call). That
+made them invisible and uncontrollable — you couldn't pause, edit, retarget, or
+add a channel without a code change.
+
+The migration moved each of those sends behind a **flow event**. Now:
+
+- The source code only **emits an event** (`flowEventService.emit(...)` on the
+  frontend, `emitFlowEvent(...)` in edge functions) carrying a fully-resolved
+  notification payload.
+- A **flow** with a matching trigger picks up the event and performs the actual
+  delivery (Create Notification / Send Email / Send Push / etc.).
+- An admin can pause, edit, re-target, or extend any of these from the **Flows**
+  admin page — no deploy required.
+
+---
+
+## 2. Architecture / execution model
+
+```
+source (frontend or edge fn)
+   |  emit event: { type, payload }
+   v
+flow-engine  (action: 'trigger-event')
+   |  find all flows where trigger_type = event AND status = 'active'
+   v
+for each matching flow -> execute graph (BFS over nodes)
+   trigger -> condition(s) -> action(s)
+```
+
+- **Frontend emit:** `src/services/flows/flowEventService.ts -> emit(eventType, data)`
+  (fire-and-forget; never throws into the calling feature).
+- **Edge emit:** `supabase/functions/_shared/flow-events.ts -> emitFlowEvent(eventType, data)`.
+- **Engine:** `supabase/functions/flow-engine/index.ts`.
+  - `trigger-event` -> runs every **active** flow whose `trigger_type` matches.
+  - `execute-flow` / `test-flow` -> run a single flow (used by **Run Now** + builder).
+- **Templating:** action configs use `{{trigger.data.fieldname}}` (and `{{item}}`
+  inside a Loop). Unresolved templates are guarded (see section 6).
+
+### Tables
+
+| Table | Purpose |
+|---|---|
+| `flows` | The flows themselves (`graph_definition` jsonb, `trigger_type`, `status`, `is_locked`, `tags`). |
+| `flow_runs` | One row per execution (status, timing, error). |
+| `flow_run_steps` | Per-node execution log within a run. |
+| `flow_area_registry` | Coverage registry — maps each platform **area** to its canonical flow. |
+| `user_notifications` | Bell notifications (written by the `create_notification` action). |
+
+---
+
+## 3. Triggers, actions, conditions
+
+### Trigger types (event vocabulary)
+Defined in `src/services/flows/types.ts` (`TriggerType`). Beyond the originals
+(`manual` is removed — use **Run Now**; plus `scheduled`, `webhook`, `user_signup`,
+quote/moodboard/profile events, etc.), the migration added:
+
+`quote_pdf_generated`, `factory_approved`, `factory_rejected`,
+`appointment_booked/confirmed/cancelled`, `svbrdf_extraction_complete`,
+`virtual_staging_completed`, `vr_world_failed`,
+`video_generation_completed/failed`, `background_agent_failed`,
+`role_upgrade_request_submitted/approved/rejected`,
+`stripe_payment_succeeded/failed`, `project_invitation_sent/resent`.
+
+### Action types (engine handlers in `flow-engine/index.ts`)
+- `create_notification` — insert into `user_notifications` (bell). Guarded.
+- `send_email` — invoke `email-api`. Guarded.
+- `send_sms` — invoke `messaging-api`.
+- `send_push` — resolve the user's `push_subscriptions` -> `notification-dispatcher`.
+- `log_event` — insert an audit/dedup-marker row (`{table, row}`).
+- `run_edge_function` — invoke any edge function with a JSON payload.
+- `send_price_alert`, `send_quote`, `build_quote`, `send_agent_message`,
+  `create_moodboard`, `add_to_moodboard`, `http_request`, plus the enrichment
+  actions (`web_search`, `firecrawl_scrape`, `apollo_enrich`,
+  `hunter_find_contacts`, `zerobounce_validate`).
+
+### Conditions
+- `if_else`, `switch`, `filter`, `delay` — implemented.
+- `loop` — implemented. Config `{ collection_field, item_variable, max_iterations }`.
+  Runs the directly-connected downstream action node(s) once per item in the
+  collection, exposing `{{item}}` and `loop_index`. Single-level body; hard cap 1000.
+  Used by the quote admin fan-out flows.
+- `stop` — hard short-circuit of a branch (pair with `if_else` for dedup).
+
+---
+
+## 4. Converted events -> default flows
+
+All default flows are tagged `system-default` and seeded **active**. Each source
+emits an enriched payload (`user_id`/recipient, `title`, `body`, `action_url`,
+`type`, plus event-specific fields).
+
+| Area (trigger) | Source | Delivery |
+|---|---|---|
+| `hire_me_received` | `HireMeModal.tsx` | Create Notification |
+| `profile_followed` | `FollowButton.tsx` | Create Notification |
+| `material_reviewed` | `MaterialReviews.tsx` | Create Notification (owner) |
+| `preferred_factory_added` | `ProfileTab.tsx` | Create Notification (factory) |
+| `vr_world_created` / `vr_world_failed` | `generate-vr-world` | Create Notification |
+| `virtual_staging_completed` | `generate-virtual-staging` | Create Notification |
+| `video_generation_completed` / `_failed` | `generate-interior-video-v2` | Create Notification |
+| `svbrdf_extraction_complete` | `svbrdfExtractionAPI.ts` | Create Notification |
+| `agent_search_completed` / `background_agent_failed` | `background-agent-runner` | Create Notification |
+| `role_upgrade_request_submitted` | `role-upgrade-requests` | Create Notification (per-admin emit) |
+| `role_upgrade_approved` / `_rejected` | `role-upgrade-requests` | Create Notification |
+| `factory_approved` / `factory_rejected` | `FactoryRegistrationsTab.tsx` | Create Notification |
+| `appointment_booked` | `BookingModal.tsx` | Create Notification (professional) |
+| `appointment_confirmed` / `_cancelled` | `AppointmentsPage.tsx` | Create Notification (client) |
+| `quote_approved` / `quote_rejected` | `QuotesService.ts` | **Loop** over `admin_ids` -> Create Notification |
+| `quote_pdf_generated` | `generate-quote-pdf` | Create Notification |
+| `stripe_payment_succeeded` / `_failed` | `stripe-webhooks` | Create Notification |
+| `project_invitation_sent` / `_resent` | `projectsService.ts` | Send Email |
+
+> The **credit grant** in `stripe-webhooks` stays in the webhook; only the
+> notification was moved to a flow.
+
+---
+
+## 5. Governance — locking & System Areas
+
+Because these flows are wired to real platform functionality, two protections
+exist so a flow can't be accidentally deleted or an area left without a handler.
+
+### 5a. Lock / unlock (prevent deletion)
+- `flows.is_locked boolean` (default false). All `system-default` flows are locked.
+- **UI:** the **My Flows** tab shows a Locked badge; the row's "..." menu has
+  **Lock (prevent delete)** / **Unlock (allow delete)**, and **Delete** is disabled
+  while locked.
+- **DB enforcement:** a `BEFORE DELETE` trigger (`prevent_locked_flow_delete`)
+  raises an error if `is_locked` — so even a direct API/SQL delete is blocked
+  until the flow is unlocked. The frontend surfaces this as a clear message.
+
+### 5b. System Areas (coverage registry)
+- `flow_area_registry` — one row per platform area that should always have a flow
+  pointed at it: `{ area_key, title, description, category, trigger_type,
+  required, bound_flow_id, sort_order }`.
+- **UI:** the **System Areas** tab groups areas by category and shows each as
+  **Linked** (green) or **Empty** (red). A per-row dropdown lists every flow whose
+  `trigger_type` matches the area; picking one sets `bound_flow_id`, choosing
+  "Empty" clears it. A header badge warns when any **required** area is empty.
+- This is the "always something is pointed to that area" guarantee: coverage is
+  visible at a glance and one click away from being restored.
+
+> Note: `bound_flow_id` is the **declared canonical handler** for visibility/governance.
+> The engine still dispatches by `trigger_type` to all active matching flows, so
+> binding is a coverage/ownership signal, not a routing switch. (A future option is
+> to make the engine prefer the bound flow exclusively — deliberately not done yet.)
+
+---
+
+## 6. Deploy-order safety
+
+The seeded flows are live in the DB before the emitting code ships. To keep the
+transition clean in **any** order:
+
+- `create_notification` **skips** (no row) if the templated `user_id` or `title`
+  didn't resolve (still contains `{{`).
+- `send_email` **skips** if the templated `to` didn't resolve.
+- Old (pre-migration) clients that emit id-only payloads therefore cause a clean
+  skip rather than a broken notification; meanwhile any still-hardcoded insert
+  keeps delivering until its source ships. No double-sends, no lost notifications.
+
+---
+
+## 7. How to operate
+
+- **Run a flow on demand:** My Flows -> **Run Now** (works for any flow regardless
+  of trigger; there is no "Manual Trigger" node).
+- **Pause a notification:** My Flows -> "..." -> **Pause** (the source still emits;
+  nothing is delivered until reactivated).
+- **Edit the message/recipient/channel:** open the flow in the **Flow Builder**,
+  edit the action node config (uses `{{trigger.data.*}}` templates).
+- **Protect a flow:** "..." -> **Lock**. **Restore coverage:** **System Areas** -> pick
+  a flow for the empty area.
+- **Add a channel** (e.g. also send a push): add a `send_push` action node to the
+  flow alongside `create_notification`.
+
+---
+
+## 8. How to add a NEW converted event
+
+1. Add the trigger string to `TriggerType` (+ config interface + the exhaustive
+   icon/label maps + palette entry) in `src/services/flows/types.ts`,
+   `MyFlowsTab.tsx`, `nodes/TriggerNode.tsx`, `panels/configs/TriggerConfigForm.tsx`,
+   `utils/paletteItems.ts`.
+2. In the source, replace the hardcoded send with an emit carrying the full
+   payload (`user_id`/recipient, `title`, `body`, `action_url`, `type`).
+3. Seed an **active** default flow (trigger -> `create_notification` / `send_email`),
+   tag it `system-default`, and lock it.
+4. Add a `flow_area_registry` row for the new area and bind it to the seeded flow.
+5. Typecheck (`npx tsc -p tsconfig.json --noEmit`) and deploy.
+
+---
+
+## 9. Known follow-ups (not yet converted)
+
+- `stripe` **invoice_paid** notification — needs an `invoice_paid` trigger type.
+- **Finance statement** email (`finance-send-statement`) — needs `send_email`
+  attachment support (it sends a PDF).
+- **Email channel** for role-upgrade / factory — needs `send_email` to support
+  `template_slug` + `variables` (the bell channel is already on flows).
+- **Python monitoring** (price / mention / job alerts) — detection + credit
+  metering intentionally stay in Python; only a future emit-to-flow bridge +
+  `debit_credits` action would move channel fan-out into Flows.
+
+---
+
+## 10. Source map (quick reference)
+
+| Concern | File |
+|---|---|
+| Engine (actions, conditions, loop, guards) | `supabase/functions/flow-engine/index.ts` |
+| Frontend emit | `src/services/flows/flowEventService.ts` |
+| Edge emit | `supabase/functions/_shared/flow-events.ts` |
+| Types (Flow, triggers, area registry) | `src/services/flows/types.ts` |
+| Service (CRUD, lock, areas) | `src/services/flows/flowService.ts` |
+| Admin UI shell + tabs | `src/components/Admin/FlowsManagement/FlowsManagement.tsx` |
+| My Flows (Run Now, lock) | `src/components/Admin/FlowsManagement/MyFlowsTab.tsx` |
+| System Areas tab | `src/components/Admin/FlowsManagement/SystemAreasTab.tsx` |

--- a/src/components/Admin/FlowsManagement/FlowsManagement.tsx
+++ b/src/components/Admin/FlowsManagement/FlowsManagement.tsx
@@ -5,6 +5,7 @@ import {
   Clock,
   CheckCircle2,
   Settings,
+  LayoutGrid,
 } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/core/ui/tabs';
 import { Card, CardContent } from '@/components/core/ui/card';
@@ -12,6 +13,7 @@ import { GlobalAdminHeader } from '../GlobalAdminHeader';
 import { MyFlowsTab } from './MyFlowsTab';
 import { FlowBuilderTab } from './FlowBuilderTab';
 import { RunHistoryTab } from './RunHistoryTab';
+import { SystemAreasTab } from './SystemAreasTab';
 import { flowService } from '@/services/flows';
 import type { Flow } from '@/services/flows';
 import { useToast } from '@/hooks/use-toast';
@@ -124,6 +126,10 @@ export const FlowsManagement: React.FC = () => {
               <Settings className="h-4 w-4" />
               Flow Builder
             </TabsTrigger>
+            <TabsTrigger value="areas" className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
+              <LayoutGrid className="h-4 w-4" />
+              System Areas
+            </TabsTrigger>
             <TabsTrigger value="history" className="gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
               <Clock className="h-4 w-4" />
               Run History
@@ -144,6 +150,17 @@ export const FlowsManagement: React.FC = () => {
 
           <TabsContent value="builder">
             <FlowBuilderTab flowId={selectedFlowId} />
+          </TabsContent>
+
+          <TabsContent value="areas">
+            <SystemAreasTab
+              flows={flows}
+              onRefresh={loadData}
+              onOpenBuilder={(flowId) => {
+                setSelectedFlowId(flowId);
+                setActiveTab('builder');
+              }}
+            />
           </TabsContent>
 
           <TabsContent value="history">

--- a/src/components/Admin/FlowsManagement/MyFlowsTab.tsx
+++ b/src/components/Admin/FlowsManagement/MyFlowsTab.tsx
@@ -31,6 +31,8 @@ import {
   LayoutGrid,
   ImagePlus,
   Share2,
+  Lock,
+  Unlock,
 } from 'lucide-react';
 import { Button } from '@/components/core/ui/button';
 import { Card, CardContent } from '@/components/core/ui/card';
@@ -202,6 +204,25 @@ export const MyFlowsTab: React.FC<MyFlowsTabProps> = ({
     }
   };
 
+  const handleToggleLock = async (flow: Flow) => {
+    try {
+      await flowService.setFlowLocked(flow.id, !flow.is_locked);
+      toast({
+        title: flow.is_locked ? 'Unlocked' : 'Locked',
+        description: flow.is_locked
+          ? `"${flow.name}" can now be deleted.`
+          : `"${flow.name}" is protected from deletion.`,
+      });
+      onRefresh();
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to update lock',
+        variant: 'destructive',
+      });
+    }
+  };
+
   const handleCreate = async () => {
     if (!newFlow.name.trim()) {
       toast({ title: 'Error', description: 'Flow name is required', variant: 'destructive' });
@@ -332,6 +353,12 @@ export const MyFlowsTab: React.FC<MyFlowsTabProps> = ({
                         <Badge variant="outline" className={statusColors[flow.status]}>
                           {flow.status}
                         </Badge>
+                        {flow.is_locked && (
+                          <Badge variant="outline" className="gap-1 bg-amber-500/10 text-amber-500">
+                            <Lock className="h-3 w-3" />
+                            Locked
+                          </Badge>
+                        )}
                       </div>
                       <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
                         <span>Trigger: {triggerLabels[flow.trigger_type] || flow.trigger_type}</span>
@@ -398,13 +425,27 @@ export const MyFlowsTab: React.FC<MyFlowsTabProps> = ({
                           <Copy className="h-4 w-4 mr-2" />
                           Duplicate
                         </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => handleToggleLock(flow)}>
+                          {flow.is_locked ? (
+                            <>
+                              <Unlock className="h-4 w-4 mr-2" />
+                              Unlock (allow delete)
+                            </>
+                          ) : (
+                            <>
+                              <Lock className="h-4 w-4 mr-2" />
+                              Lock (prevent delete)
+                            </>
+                          )}
+                        </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           onClick={() => handleDelete(flow)}
+                          disabled={flow.is_locked}
                           className="text-destructive"
                         >
                           <Trash2 className="h-4 w-4 mr-2" />
-                          Delete
+                          {flow.is_locked ? 'Delete (locked)' : 'Delete'}
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>

--- a/src/components/Admin/FlowsManagement/SystemAreasTab.tsx
+++ b/src/components/Admin/FlowsManagement/SystemAreasTab.tsx
@@ -1,0 +1,212 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { CheckCircle2, AlertTriangle, Link2, ExternalLink } from 'lucide-react';
+import { Card, CardContent } from '@/components/core/ui/card';
+import { Badge } from '@/components/core/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/core/ui/select';
+import { flowService } from '@/services/flows';
+import type { Flow, FlowAreaRegistryEntry } from '@/services/flows';
+import { useToast } from '@/hooks/use-toast';
+
+interface SystemAreasTabProps {
+  flows: Flow[];
+  onOpenBuilder: (flowId: string) => void;
+  onRefresh: () => void;
+}
+
+const NONE = '__none__';
+
+/**
+ * System Areas — the coverage registry. Each row is a platform area (mapped to a
+ * trigger_type) that should always have a flow pointed at it. The picker lets an
+ * admin bind any matching flow; rows with no bound flow render as "empty" so a
+ * required area is never silently left without a handler.
+ */
+export const SystemAreasTab: React.FC<SystemAreasTabProps> = ({ flows, onOpenBuilder, onRefresh }) => {
+  const [areas, setAreas] = useState<FlowAreaRegistryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  const loadAreas = useCallback(async () => {
+    try {
+      setLoading(true);
+      setAreas(await flowService.listAreas());
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to load system areas',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    loadAreas();
+  }, [loadAreas]);
+
+  // Flows grouped by trigger_type so each area only offers compatible flows.
+  const flowsByTrigger = useMemo(() => {
+    const map = new Map<string, Flow[]>();
+    for (const f of flows) {
+      const arr = map.get(f.trigger_type) ?? [];
+      arr.push(f);
+      map.set(f.trigger_type, arr);
+    }
+    return map;
+  }, [flows]);
+
+  const handleBind = async (area: FlowAreaRegistryEntry, value: string) => {
+    const flowId = value === NONE ? null : value;
+    try {
+      setSavingKey(area.area_key);
+      await flowService.bindArea(area.area_key, flowId);
+      setAreas((prev) =>
+        prev.map((a) => (a.area_key === area.area_key ? { ...a, bound_flow_id: flowId } : a)),
+      );
+      toast({
+        title: flowId ? 'Area linked' : 'Area cleared',
+        description: flowId
+          ? `"${area.title}" is now handled by the selected flow.`
+          : `"${area.title}" has no flow — events will not be delivered.`,
+        variant: flowId ? undefined : 'destructive',
+      });
+      onRefresh();
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to update area',
+        variant: 'destructive',
+      });
+    } finally {
+      setSavingKey(null);
+    }
+  };
+
+  const grouped = useMemo(() => {
+    const g = new Map<string, FlowAreaRegistryEntry[]>();
+    for (const a of areas) {
+      const arr = g.get(a.category) ?? [];
+      arr.push(a);
+      g.set(a.category, arr);
+    }
+    return Array.from(g.entries());
+  }, [areas]);
+
+  const emptyRequired = areas.filter((a) => a.required && !a.bound_flow_id).length;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Coverage summary */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {areas.length} platform areas · each should point to a flow so its notification is always delivered.
+        </p>
+        {emptyRequired > 0 ? (
+          <Badge variant="outline" className="gap-1 bg-red-500/10 text-red-500">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            {emptyRequired} required area{emptyRequired !== 1 ? 's' : ''} empty
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="gap-1 bg-emerald-500/10 text-emerald-500">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            All required areas covered
+          </Badge>
+        )}
+      </div>
+
+      {grouped.map(([category, rows]) => (
+        <Card key={category}>
+          <CardContent className="p-0">
+            <div className="px-4 py-2 border-b text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {category}
+            </div>
+            <div className="divide-y">
+              {rows.map((area) => {
+                const candidates = flowsByTrigger.get(area.trigger_type) ?? [];
+                const isEmpty = !area.bound_flow_id;
+                return (
+                  <div key={area.area_key} className="flex items-center gap-4 px-4 py-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium truncate">{area.title}</span>
+                        {isEmpty ? (
+                          <Badge variant="outline" className="gap-1 bg-red-500/10 text-red-500">
+                            <AlertTriangle className="h-3 w-3" />
+                            Empty
+                          </Badge>
+                        ) : (
+                          <Badge variant="outline" className="gap-1 bg-emerald-500/10 text-emerald-500">
+                            <Link2 className="h-3 w-3" />
+                            Linked
+                          </Badge>
+                        )}
+                      </div>
+                      {area.description && (
+                        <p className="text-xs text-muted-foreground mt-0.5 truncate">{area.description}</p>
+                      )}
+                      <p className="text-[10px] text-muted-foreground/70 font-mono mt-0.5">
+                        trigger: {area.trigger_type}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Select
+                        value={area.bound_flow_id ?? NONE}
+                        onValueChange={(v) => handleBind(area, v)}
+                        disabled={savingKey === area.area_key}
+                      >
+                        <SelectTrigger className="h-8 text-sm w-[260px]">
+                          <SelectValue placeholder="Select a flow…" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={NONE}>
+                            <span className="text-muted-foreground">— Empty (no flow) —</span>
+                          </SelectItem>
+                          {candidates.map((f) => (
+                            <SelectItem key={f.id} value={f.id}>
+                              {f.name} {f.status !== 'active' ? `(${f.status})` : ''}
+                            </SelectItem>
+                          ))}
+                          {candidates.length === 0 && (
+                            <SelectItem value="__noflows__" disabled>
+                              No flows for this trigger yet
+                            </SelectItem>
+                          )}
+                        </SelectContent>
+                      </Select>
+                      {area.bound_flow_id && (
+                        <button
+                          onClick={() => onOpenBuilder(area.bound_flow_id!)}
+                          className="text-muted-foreground hover:text-foreground"
+                          title="Open in builder"
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/src/services/flows/flowService.ts
+++ b/src/services/flows/flowService.ts
@@ -6,6 +6,7 @@ import type {
   FlowRunStep,
   FlowGraphDefinition,
   TriggerType,
+  FlowAreaRegistryEntry,
 } from './types';
 
 interface ListFlowsFilters {
@@ -92,7 +93,39 @@ class FlowService {
 
   async deleteFlow(id: string): Promise<void> {
     const { error } = await supabase.from('flows').delete().eq('id', id);
-    if (error) throw new Error(`Failed to delete flow: ${error.message}`);
+    if (error) {
+      // The DB trigger raises a clear message for locked flows; surface it.
+      throw new Error(
+        /locked/i.test(error.message)
+          ? 'This flow is locked and cannot be deleted. Unlock it first.'
+          : `Failed to delete flow: ${error.message}`,
+      );
+    }
+  }
+
+  /** Lock or unlock a flow. Locked flows are protected from deletion. */
+  async setFlowLocked(id: string, locked: boolean): Promise<void> {
+    const { error } = await supabase.from('flows').update({ is_locked: locked }).eq('id', id);
+    if (error) throw new Error(`Failed to ${locked ? 'lock' : 'unlock'} flow: ${error.message}`);
+  }
+
+  // ── System Areas (coverage registry) ────────────────────
+  async listAreas(): Promise<FlowAreaRegistryEntry[]> {
+    const { data, error } = await supabase
+      .from('flow_area_registry')
+      .select('*')
+      .order('sort_order', { ascending: true });
+    if (error) throw new Error(`Failed to list areas: ${error.message}`);
+    return (data ?? []) as unknown as FlowAreaRegistryEntry[];
+  }
+
+  /** Point an area at a specific flow (or clear it by passing null). */
+  async bindArea(areaKey: string, flowId: string | null): Promise<void> {
+    const { error } = await supabase
+      .from('flow_area_registry')
+      .update({ bound_flow_id: flowId })
+      .eq('area_key', areaKey);
+    if (error) throw new Error(`Failed to bind area: ${error.message}`);
   }
 
   async duplicateFlow(id: string, newName: string): Promise<Flow> {

--- a/src/services/flows/index.ts
+++ b/src/services/flows/index.ts
@@ -16,6 +16,7 @@ export type {
   FlowGraphNode,
   FlowGraphEdge,
   Flow,
+  FlowAreaRegistryEntry,
   FlowRun,
   FlowRunStep,
   NodePaletteItem,

--- a/src/services/flows/types.ts
+++ b/src/services/flows/types.ts
@@ -527,10 +527,30 @@ export interface Flow {
   graph_definition: FlowGraphDefinition;
   version: number;
   tags: string[];
+  /** When true, the flow cannot be deleted (also enforced by a DB trigger). */
+  is_locked?: boolean;
   created_by: string | null;
   updated_by: string | null;
   last_run_at: string | null;
   run_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * A platform "area" that should always have a flow pointed at it. Each area maps
+ * to a trigger_type; `bound_flow_id` records the canonical handler flow. The
+ * System Areas tab surfaces each area as filled or empty so coverage is visible.
+ */
+export interface FlowAreaRegistryEntry {
+  area_key: string;
+  title: string;
+  description: string | null;
+  category: string;
+  trigger_type: TriggerType;
+  required: boolean;
+  bound_flow_id: string | null;
+  sort_order: number;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## What this adds

Governance for the platform-wired flows so they are safe to operate, plus full documentation.

### Lock / unlock (prevent deletion)
- New `flows.is_locked` column; all 27 `system-default` flows are locked.
- A `BEFORE DELETE` trigger blocks deletion of locked flows at the DB level (defense beyond the UI), surfaced as a clear message.
- **My Flows** tab: a Locked badge, a **Lock / Unlock** row-menu item, and **Delete** disabled while locked.

### System Areas (coverage registry)
- New `flow_area_registry` table maps every platform **area** (a `trigger_type`) to its canonical flow (`bound_flow_id`). Seeded with all 27 areas, all currently bound.
- New **System Areas** tab: areas grouped by category, each shown **Linked** or **Empty**, with a per-area dropdown listing every flow matching that trigger. Picking one binds it; "Empty" clears it. A header badge warns when any required area is empty.
- Delivers the "always something is pointed to that area" guarantee.

### Docs
- `docs/flows-notification-system.md` - the single reference: architecture/execution model, the full event->flow map (27 areas), triggers/actions/conditions, governance, deploy-order safety, how to add a new converted event, follow-ups, source map.

### DB
Applied via migration `flows_lock_and_area_registry`. Verified: 27 locked, 27 areas bound, 0 required-empty, delete-guard present. Frontend typechecks clean. Independent of #165 (no file overlap).

Generated with Claude Code
