### PR TITLE
fix(ops): repair api_usage_logs read/write schema mismatch (0 rows logged)

### DIFF
--- a/src/components/Admin/ApiGatewayAdmin.tsx
+++ b/src/components/Admin/ApiGatewayAdmin.tsx
@@ -77,7 +77,7 @@ export const ApiGatewayAdmin: React.FC = () => {
     rateLimitedRequests: number;
     avgResponseTime: number;
     topEndpoints: Array<{ path: string; count: number }>;
-    recentLogs: Array<{ endpoint: string; method: string; status_code: number; response_time_ms: number | null; created_at: string | null; ip_address: string | null }>;
+    recentLogs: Array<{ request_path: string; request_method: string; response_status: number | null; response_time_ms: number | null; created_at: string | null; ip_address: string | null }>;
   }>({
     totalRequests: 0, successfulRequests: 0, rateLimitedRequests: 0, avgResponseTime: 0,
     topEndpoints: [], recentLogs: [],
@@ -111,13 +111,13 @@ export const ApiGatewayAdmin: React.FC = () => {
     try {
       const logs = await apiGatewayService.getApiUsageLogs({ limit: 500 });
       const totalRequests = logs.length;
-      const successfulRequests = logs.filter((l) => l.status_code >= 200 && l.status_code < 400).length;
-      const rateLimitedRequests = logs.filter((l) => l.status_code === 429).length;
+      const successfulRequests = logs.filter((l) => (l.response_status ?? 0) >= 200 && (l.response_status ?? 0) < 400).length;
+      const rateLimitedRequests = logs.filter((l) => l.response_status === 429).length;
       const times = logs.map((l) => l.response_time_ms).filter((t): t is number => t != null);
       const avgResponseTime = times.length > 0 ? times.reduce((a, b) => a + b, 0) / times.length : 0;
 
       const endpointCounts: Record<string, number> = {};
-      logs.forEach((l) => { endpointCounts[l.endpoint] = (endpointCounts[l.endpoint] || 0) + 1; });
+      logs.forEach((l) => { endpointCounts[l.request_path] = (endpointCounts[l.request_path] || 0) + 1; });
       const topEndpoints = Object.entries(endpointCounts)
         .map(([path, count]) => ({ path, count }))
         .sort((a, b) => b.count - a.count)
@@ -462,15 +462,15 @@ export const ApiGatewayAdmin: React.FC = () => {
                     <TableBody>
                       {analyticsData.recentLogs.map((log, i) => (
                         <TableRow key={i}>
-                          <TableCell className="font-mono text-xs max-w-[200px] truncate">{log.endpoint}</TableCell>
-                          <TableCell><Badge variant="outline" className="text-xs">{log.method}</Badge></TableCell>
+                          <TableCell className="font-mono text-xs max-w-[200px] truncate">{log.request_path}</TableCell>
+                          <TableCell><Badge variant="outline" className="text-xs">{log.request_method}</Badge></TableCell>
                           <TableCell>
                             <Badge className={
-                              log.status_code >= 200 && log.status_code < 300 ? 'bg-green-500/20 text-green-700 text-xs'
-                                : log.status_code === 429 ? 'bg-orange-500/20 text-orange-700 text-xs'
-                                : log.status_code >= 400 ? 'bg-red-500/20 text-red-700 text-xs'
+                              (log.response_status ?? 0) >= 200 && (log.response_status ?? 0) < 300 ? 'bg-green-500/20 text-green-700 text-xs'
+                                : log.response_status === 429 ? 'bg-orange-500/20 text-orange-700 text-xs'
+                                : (log.response_status ?? 0) >= 400 ? 'bg-red-500/20 text-red-700 text-xs'
                                 : 'text-xs'
-                            }>{log.status_code}</Badge>
+                            }>{log.response_status ?? '—'}</Badge>
                           </TableCell>
                           <TableCell className="text-xs text-muted-foreground">{log.response_time_ms != null ? `${log.response_time_ms}ms` : '—'}</TableCell>
                           <TableCell className="text-xs text-muted-foreground font-mono">{log.ip_address || '—'}</TableCell>

--- a/src/components/Admin/OperationsDashboard/OperationsDashboard.tsx
+++ b/src/components/Admin/OperationsDashboard/OperationsDashboard.tsx
@@ -331,7 +331,7 @@ const OperationsDashboardInner: React.FC = () => {
           (item: unknown) =>
             (item as any).created_at &&
             (item as any).id &&
-            (item as any).status_code !== null,
+            (item as any).response_status !== null,
         ) as ApiUsageLog[];
 
       setSearchAnalytics(filteredSearchData);
@@ -345,7 +345,7 @@ const OperationsDashboardInner: React.FC = () => {
           ?.map((s: unknown) => (s as any).user_id)
           .filter(Boolean) || []),
         ...(apiData
-          ?.map((a: unknown) => (a as any).api_key_id)
+          ?.map((a: unknown) => (a as any).user_id)
           .filter(Boolean) || []),
         ...agentChatMessages.map((m) => m.user_id).filter(Boolean),
       ]).size;
@@ -1243,11 +1243,11 @@ const OperationsDashboardInner: React.FC = () => {
                   <Table>
                     <TableHeader>
                       <TableRow>
-                        <TableHead>Endpoint</TableHead>
+                        <TableHead>Path</TableHead>
                         <TableHead>Method</TableHead>
                         <TableHead>Status</TableHead>
                         <TableHead>Response Time</TableHead>
-                        <TableHead>User</TableHead>
+                        <TableHead>Source</TableHead>
                         <TableHead>Time</TableHead>
                       </TableRow>
                     </TableHeader>
@@ -1255,24 +1255,22 @@ const OperationsDashboardInner: React.FC = () => {
                       {apiUsage.slice(0, 15).map((log) => (
                         <TableRow key={log.id}>
                           <TableCell className="font-mono text-sm max-w-xs truncate">
-                            {log.endpoint}
+                            {log.request_path}
                           </TableCell>
                           <TableCell>
                             <Badge variant="outline" className="font-mono text-xs">
-                              {log.method}
+                              {log.request_method}
                             </Badge>
                           </TableCell>
                           <TableCell>
-                            <span className={getStatusColor(log.status_code)}>
-                              {log.status_code}
+                            <span className={getStatusColor(log.response_status ?? 0)}>
+                              {log.response_status ?? '—'}
                             </span>
                           </TableCell>
                           <TableCell>{log.response_time_ms || 0}ms</TableCell>
                           <TableCell>
                             <code className="text-xs bg-muted text-foreground px-1.5 py-0.5 rounded border border-border">
-                              {log.api_key_id
-                                ? log.api_key_id.slice(0, 8) + '...'
-                                : 'Anonymous'}
+                              {log.is_internal_request ? 'Internal' : 'External'}
                             </code>
                           </TableCell>
                           <TableCell>

--- a/src/components/Admin/OperationsDashboard/types.ts
+++ b/src/components/Admin/OperationsDashboard/types.ts
@@ -79,18 +79,19 @@ export interface SearchAnalytic {
   response_time_ms: number;
 }
 
+// Mirrors the real public.api_usage_logs columns (request-shaped).
 export interface ApiUsageLog {
   id: string;
-  api_key_id: string;
-  endpoint: string;
-  method: string;
-  status_code: number;
+  user_id: string | null;
+  endpoint_id: string | null;
+  request_path: string;
+  request_method: string;
+  response_status: number | null;
   response_time_ms: number | null;
-  request_size_bytes: number | null;
-  response_size_bytes: number | null;
   ip_address: string | null;
   user_agent: string | null;
-  error_message: string | null;
+  is_internal_request: boolean;
+  rate_limit_exceeded: boolean;
   created_at: string | null;
 }
 

--- a/src/services/apiGateway/apiGatewayService.ts
+++ b/src/services/apiGateway/apiGatewayService.ts
@@ -14,18 +14,19 @@ export interface ApiKey {
   updated_at: string;
 }
 
+// Mirrors the real public.api_usage_logs columns (request-shaped).
 export interface ApiUsageLog {
   id: string;
-  api_key_id: string;
-  endpoint: string;
-  method: string;
-  status_code: number;
+  user_id: string | null;
+  endpoint_id: string | null;
+  request_path: string;
+  request_method: string;
+  response_status: number | null;
   response_time_ms: number | null;
-  request_size_bytes: number | null;
-  response_size_bytes: number | null;
   ip_address: string | null;
   user_agent: string | null;
-  error_message: string | null;
+  is_internal_request: boolean;
+  rate_limit_exceeded: boolean;
   created_at: string | null;
 }
 
@@ -100,7 +101,7 @@ class ApiGatewayService {
     startDate?: string;
     endDate?: string;
     endpoint?: string;
-    apiKeyId?: string;
+    userId?: string;
     limit?: number;
   }): Promise<ApiUsageLog[]> {
     let query = supabase
@@ -115,10 +116,11 @@ class ApiGatewayService {
       query = query.lte('created_at', options.endDate);
     }
     if (options?.endpoint) {
-      query = query.eq('endpoint', options.endpoint);
+      // `endpoint` here is the request path (the function name / route).
+      query = query.eq('request_path', options.endpoint);
     }
-    if (options?.apiKeyId) {
-      query = query.eq('api_key_id', options.apiKeyId);
+    if (options?.userId) {
+      query = query.eq('user_id', options.userId);
     }
     if (options?.limit) {
       query = query.limit(options.limit);

--- a/supabase/functions/_shared/api-logger.ts
+++ b/supabase/functions/_shared/api-logger.ts
@@ -1,15 +1,20 @@
 /**
  * API Usage Logger — Shared Edge Function Wrapper
  *
- * Wraps any edge function handler to automatically log every request
- * to the `api_usage_logs` table. Captures:
- *   - endpoint (function name)
- *   - HTTP method
- *   - status code
- *   - response time (ms)
- *   - client IP
- *   - user agent
- *   - error message (on 4xx/5xx)
+ * Wraps any edge function handler to automatically log every request to the
+ * `api_usage_logs` table. Column mapping (the table is request-shaped, not
+ * "endpoint/method/status" shaped — this mismatch silently failed every insert
+ * until it was fixed 2026-05-31):
+ *   request_path        ← function name
+ *   request_method      ← HTTP method
+ *   response_status     ← status code
+ *   response_time_ms    ← duration
+ *   ip_address          ← client IP (NOT NULL — falls back to '0.0.0.0')
+ *   user_agent          ← UA header
+ *   is_internal_request ← service-role / internal Bearer call
+ *
+ * The table has no error-message column, so 4xx/5xx detail is logged to the
+ * function console only; failures are still visible via response_status.
  *
  * Usage:
  *   import { withApiLogging } from '../_shared/api-logger.ts';
@@ -33,21 +38,20 @@ export function withApiLogging(functionName: string, handler: Handler): Handler 
       return handler(req);
     }
 
+    // ip_address is NOT NULL on the table — fall back to a sentinel rather than
+    // letting the insert fail (which is exactly what used to happen).
     const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
       || req.headers.get('cf-connecting-ip')
       || req.headers.get('x-real-ip')
-      || null;
+      || '0.0.0.0';
     const userAgent = req.headers.get('user-agent') || null;
     const method = req.method;
 
-    // Extract user/key from auth header for tracking
+    // A service-role / internal Bearer call (cron, function-to-function) vs a
+    // real external caller. Used for the is_internal_request flag.
     const authHeader = req.headers.get('authorization') || '';
-    const apiKeyHeader = req.headers.get('x-api-key') || req.headers.get('apikey') || '';
-    const apiKeyId = apiKeyHeader
-      ? apiKeyHeader.slice(0, 12) + '…'
-      : authHeader.startsWith('Bearer ')
-        ? 'jwt'
-        : 'anonymous';
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+    const isInternal = !!serviceRoleKey && authHeader === `Bearer ${serviceRoleKey}`;
 
     let response: Response;
     let errorMessage: string | null = null;
@@ -66,7 +70,8 @@ export function withApiLogging(functionName: string, handler: Handler): Handler 
     const statusCode = response.status;
 
     if (statusCode >= 400) {
-      // Try to capture error from response body without consuming it
+      // The table has no error column — surface the error to the function log
+      // so it's still findable, without blocking the response.
       try {
         const cloned = response.clone();
         const body = await cloned.text();
@@ -75,10 +80,13 @@ export function withApiLogging(functionName: string, handler: Handler): Handler 
       } catch {
         // Body not JSON or already consumed — skip
       }
+      if (errorMessage) {
+        console.error(`[api-logger] ${functionName} ${statusCode}: ${errorMessage}`);
+      }
     }
 
     // Fire-and-forget — never block the response
-    logToDb(functionName, method, statusCode, durationMs, ip, userAgent, apiKeyId, errorMessage).catch(
+    logToDb(functionName, method, statusCode, durationMs, ip, userAgent, isInternal).catch(
       (err) => console.error('[api-logger] Failed to log:', err.message),
     );
 
@@ -87,14 +95,13 @@ export function withApiLogging(functionName: string, handler: Handler): Handler 
 }
 
 async function logToDb(
-  endpoint: string,
-  method: string,
-  statusCode: number,
+  requestPath: string,
+  requestMethod: string,
+  responseStatus: number,
   responseTimeMs: number,
-  ipAddress: string | null,
+  ipAddress: string,
   userAgent: string | null,
-  apiKeyId: string,
-  errorMessage: string | null,
+  isInternal: boolean,
 ): Promise<void> {
   const supabaseUrl = Deno.env.get('SUPABASE_URL');
   const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
@@ -102,15 +109,15 @@ async function logToDb(
 
   const supabase = createClient(supabaseUrl, supabaseKey);
 
-  await supabase.from('api_usage_logs').insert({
-    api_key_id: apiKeyId,
-    endpoint,
-    method,
-    status_code: statusCode,
+  const { error } = await supabase.from('api_usage_logs').insert({
+    request_path: requestPath,
+    request_method: requestMethod,
+    response_status: responseStatus,
     response_time_ms: responseTimeMs,
     ip_address: ipAddress,
     user_agent: userAgent,
-    error_message: errorMessage,
+    is_internal_request: isInternal,
     created_at: new Date().toISOString(),
   });
+  if (error) console.error('[api-logger] insert failed:', error.message);
 }

--- a/supabase/functions/_shared/config.ts
+++ b/supabase/functions/_shared/config.ts
@@ -445,17 +445,23 @@ export class Logger {
     error_message?: string;
   }): Promise<void> {
     try {
+      // Map the friendly input shape onto the real `api_usage_logs` columns
+      // (request_path / request_method / response_status; ip_address NOT NULL).
+      // The previous insert used endpoint/method/status_code/api_key_id/
+      // error_message — none of which exist on the table — so every call
+      // silently failed. The table has no error column; errors go to the log.
+      if (logData.error_message) {
+        console.error(`[Logger] ${logData.endpoint} ${logData.status_code}: ${logData.error_message}`);
+      }
       const { error } = await supabase
         .from('api_usage_logs')
         .insert({
-          api_key_id: logData.api_key_id ?? 'anonymous',
-          endpoint: logData.endpoint,
-          method: logData.method,
-          status_code: logData.status_code,
+          request_path: logData.endpoint,
+          request_method: logData.method,
+          response_status: logData.status_code,
           response_time_ms: logData.response_time_ms ?? null,
-          ip_address: logData.ip_address ?? null,
+          ip_address: logData.ip_address ?? '0.0.0.0',
           user_agent: logData.user_agent ?? null,
-          error_message: logData.error_message ?? null,
           created_at: new Date().toISOString(),
         });
 


### PR DESCRIPTION
## The bug

The `api_usage_logs` table is **request-shaped** (`request_path`, `request_method`, `response_status`, `ip_address` NOT NULL, `is_internal_request`), but every writer and reader used a **phantom shape** (`endpoint`, `method`, `status_code`, `api_key_id`, `error_message` — none of which exist on the table).

**Impact:** every request-logging insert across ~29 edge functions (via the `withApiLogging` wrapper) **silently failed** — the table has **0 rows total**. And the admin views that read it referenced non-existent columns. Surfaced while building the webhook monitoring panel (#168).

## The fix (full read+write path)

**Writers** — map onto the real columns:
- `_shared/api-logger.ts` (the `withApiLogging` wrapper used everywhere) — `request_path`/`request_method`/`response_status`/`response_time_ms`/`ip_address` (`'0.0.0.0'` fallback for the NOT NULL column)/`user_agent`/`is_internal_request` (derived from a service-role Bearer). The table has no error column, so 4xx/5xx detail now goes to the function console, and previously-swallowed insert errors are now logged.
- `_shared/config.ts` (`Logger.logApiUsage`) — same mapping; the caller's friendly input shape is preserved so its one caller is untouched.

**Readers** — use the real columns:
- `OperationsDashboard` API Request Logs table + the filter/unique-users logic.
- `OperationsDashboard/types.ts` + `apiGateway/apiGatewayService.ts` `ApiUsageLog` interfaces rewritten to the real schema; `getApiUsageLogs` filters by `request_path` / `user_id`.
- `ApiGatewayAdmin` analytics + recent-logs table.

## Re: "the AI also"
I checked `ai_usage_logs` (AI cost/token logging) — it's **healthy**: 5,706 rows, writers use the correct columns. So there was no second broken table; the AI logging works. This fix is **request-logging only**.

## Verification
- A corrected insert (real columns) is **accepted by the live table** (smoke-tested, row then deleted).
- Frontend typecheck clean (0 errors).
- Built in an isolated git worktree; no other working-tree changes.

Once deployed, `api_usage_logs` will start populating and the **API Request Logs** card in Operations (and the API Gateway analytics) will show real data instead of staying empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)