### PR TITLE
feat(flows): variable helpers in flow editor + email builder, wire email template variables

### DIFF
--- a/src/components/Admin/FlowsManagement/panels/NodeConfigPanel.tsx
+++ b/src/components/Admin/FlowsManagement/panels/NodeConfigPanel.tsx
@@ -8,6 +8,7 @@ import { useFlowBuilder } from '../hooks/useFlowBuilder';
 import { TriggerConfigForm } from './configs/TriggerConfigForm';
 import { ConditionConfigForm } from './configs/ConditionConfigForm';
 import { ActionConfigForm } from './configs/ActionConfigForm';
+import { VariablesHelper } from './VariablesHelper';
 import type { FlowNodeData, TriggerNodeData, ConditionNodeData, ActionNodeData } from '@/services/flows/types';
 
 const categoryLabels: Record<string, string> = {
@@ -25,6 +26,7 @@ const categoryColors: Record<string, string> = {
 export function NodeConfigPanel() {
   const selectedNodeId = useFlowBuilder((s) => s.selectedNodeId);
   const nodes = useFlowBuilder((s) => s.nodes);
+  const edges = useFlowBuilder((s) => s.edges);
   const updateNodeData = useFlowBuilder((s) => s.updateNodeData);
   const deleteNode = useFlowBuilder((s) => s.deleteNode);
   const selectNode = useFlowBuilder((s) => s.selectNode);
@@ -34,6 +36,21 @@ export function NodeConfigPanel() {
   if (!selectedNode) return null;
 
   const nodeData = selectedNode.data as FlowNodeData;
+
+  // The flow's trigger drives which {{trigger.data.*}} variables are offered.
+  const triggerNode = nodes.find((n) => (n.data as FlowNodeData).category === 'trigger');
+  const triggerType = triggerNode
+    ? (triggerNode.data as TriggerNodeData).triggerType
+    : undefined;
+
+  // Is the selected node directly downstream of a Loop condition? If so it can
+  // also use {{item}} / {{loop_index}}.
+  const insideLoop = edges.some((e) => {
+    if (e.target !== selectedNode.id) return false;
+    const src = nodes.find((n) => n.id === e.source);
+    const d = src?.data as FlowNodeData | undefined;
+    return d?.category === 'condition' && (d as ConditionNodeData).conditionType === 'loop';
+  });
 
   const handleLabelChange = (label: string) => {
     updateNodeData(selectedNode.id, { label } as Partial<FlowNodeData>);
@@ -95,16 +112,22 @@ export function NodeConfigPanel() {
           />
         )}
         {nodeData.category === 'condition' && (
-          <ConditionConfigForm
-            data={nodeData as ConditionNodeData}
-            onChange={handleConfigChange}
-          />
+          <>
+            <VariablesHelper triggerType={triggerType} insideLoop={insideLoop} />
+            <ConditionConfigForm
+              data={nodeData as ConditionNodeData}
+              onChange={handleConfigChange}
+            />
+          </>
         )}
         {nodeData.category === 'action' && (
-          <ActionConfigForm
-            data={nodeData as ActionNodeData}
-            onChange={handleConfigChange}
-          />
+          <>
+            <VariablesHelper triggerType={triggerType} insideLoop={insideLoop} />
+            <ActionConfigForm
+              data={nodeData as ActionNodeData}
+              onChange={handleConfigChange}
+            />
+          </>
         )}
 
         <Separator />

--- a/src/components/Admin/FlowsManagement/panels/VariablesHelper.tsx
+++ b/src/components/Admin/FlowsManagement/panels/VariablesHelper.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { Copy, Check, ChevronDown, ChevronRight, Braces } from 'lucide-react';
+import { Badge } from '@/components/core/ui/badge';
+import { getTriggerVariables, LOOP_VARIABLES } from '@/services/flows/triggerVariables';
+
+interface VariablesHelperProps {
+  /** The flow's trigger type (drives which variables are shown). */
+  triggerType: string | undefined;
+  /** Whether the selected action sits downstream of a Loop (adds {{item}} etc.). */
+  insideLoop?: boolean;
+}
+
+/**
+ * Shows the `{{trigger.data.*}}` variables available for the current flow's
+ * trigger, so an operator knows what they can paste into an action's config
+ * fields. Click a token to copy it. Collapsible to stay out of the way.
+ */
+export const VariablesHelper: React.FC<VariablesHelperProps> = ({ triggerType, insideLoop }) => {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const vars = getTriggerVariables(triggerType);
+  const loopVars = insideLoop
+    ? LOOP_VARIABLES.map((v) => ({ ...v, token: v.key === 'loop_index' ? '{{loop_index}}' : `{{${v.key}}}` }))
+    : [];
+
+  const copy = async (token: string) => {
+    try {
+      await navigator.clipboard.writeText(token);
+      setCopied(token);
+      setTimeout(() => setCopied((c) => (c === token ? null : c)), 1200);
+    } catch {
+      /* clipboard unavailable — no-op */
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-border bg-muted/30">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between px-2.5 py-2 text-xs font-medium"
+      >
+        <span className="flex items-center gap-1.5">
+          <Braces className="h-3.5 w-3.5 text-muted-foreground" />
+          Available variables
+          <Badge variant="outline" className="text-[10px] h-4 px-1">
+            {vars.length + loopVars.length}
+          </Badge>
+        </span>
+        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+      </button>
+
+      {open && (
+        <div className="px-2.5 pb-2.5 space-y-1.5">
+          <p className="text-[10px] text-muted-foreground leading-relaxed">
+            Click to copy, then paste into any field below. Plain text overrides the value the
+            source sends; <code className="bg-muted px-1 rounded">{'{{…}}'}</code> is filled at run time.
+          </p>
+          {[...loopVars, ...vars].map((v) => (
+            <button
+              key={v.token}
+              type="button"
+              onClick={() => copy(v.token)}
+              className="w-full text-left rounded border border-border/60 bg-background/60 px-2 py-1.5 hover:border-primary/40 transition-colors group"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <code className="text-[11px] font-mono text-primary break-all">{v.token}</code>
+                {copied === v.token ? (
+                  <Check className="h-3 w-3 text-emerald-500 shrink-0" />
+                ) : (
+                  <Copy className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 shrink-0" />
+                )}
+              </div>
+              <div className="text-[10px] text-muted-foreground leading-tight mt-0.5">
+                <span className="text-foreground font-medium">{v.label}</span> — {v.note}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Admin/FlowsManagement/panels/configs/ActionConfigForm.tsx
+++ b/src/components/Admin/FlowsManagement/panels/configs/ActionConfigForm.tsx
@@ -116,13 +116,31 @@ export function ActionConfigForm({ data, onChange }: ActionConfigFormProps) {
             />
           </div>
           <div className="space-y-1.5">
-            <Label className="text-xs">Template ID (optional)</Label>
+            <Label className="text-xs">Template slug (optional)</Label>
             <Input
               value={cfg.template_id || ''}
               onChange={(e) => onChange({ ...cfg, template_id: e.target.value })}
               placeholder="welcome-email"
               className="h-8 text-sm"
             />
+            <p className="text-[10px] text-muted-foreground">
+              An <code>email_templates</code> slug. When set, the template's {'{{tag}}'} placeholders
+              are filled from the variables below (Subject/Body above are ignored).
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs">Template variables (JSON, optional)</Label>
+            <Textarea
+              value={cfg.variables || ''}
+              onChange={(e) => onChange({ ...cfg, variables: e.target.value })}
+              placeholder={'{ "firstName": "{{trigger.data.client_name}}" }'}
+              rows={3}
+              className="text-sm font-mono"
+            />
+            <p className="text-[10px] text-muted-foreground">
+              Maps the template's {'{{tag}}'} names to values. Values can use {'{{trigger.data.*}}'} —
+              see Available variables above.
+            </p>
           </div>
         </div>
       );

--- a/src/modules/email/pages/EmailTemplateBuilderPage.tsx
+++ b/src/modules/email/pages/EmailTemplateBuilderPage.tsx
@@ -19,6 +19,7 @@ import { Badge } from '@/components/core/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { getProductName, getMaterialCategory, getAvailableColors } from '@/utils/productMetadata';
+import { getTriggerVariables } from '@/services/flows/triggerVariables';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 type DeviceView = 'desktop' | 'tablet' | 'mobile';
@@ -35,6 +36,7 @@ const BRAND = {
 };
 
 // ── Template tag documentation ─────────────────────────────────────────────
+// Always-available recipient/platform tags (filled by the email send pipeline).
 const TEMPLATE_TAGS = [
   { tag: '{{firstName}}',     label: 'First Name',       example: 'Jane',                          note: 'Populated from recipient contact data when sending a campaign, or passed explicitly in the send API call.' },
   { tag: '{{lastName}}',      label: 'Last Name',        example: 'Smith',                         note: 'Same as firstName — comes from the recipient record.' },
@@ -45,6 +47,28 @@ const TEMPLATE_TAGS = [
   { tag: '{{platformUrl}}',   label: 'Platform URL',     example: 'https://materialkai.com',       note: 'The main platform URL. Set in Email Settings.' },
   { tag: '{{unsubscribeUrl}}',label: 'Unsubscribe Link', example: 'https://…/unsubscribe?token=…', note: 'Required for marketing emails. Automatically generated.' },
 ];
+
+// Platform/flow event tags: when this template is sent by a Flow's "Send Email"
+// action, the flow maps these into the template's variables. Grouped by the
+// event that triggers them so authors know which tags are available per source.
+// Derived from the shared trigger-variable catalog (single source of truth).
+const FLOW_EVENT_TAG_GROUPS: Array<{ title: string; tags: Array<{ tag: string; label: string; note: string }> }> = (
+  [
+    { title: 'Project invitation', trigger: 'project_invitation_sent' },
+    { title: 'Quote accepted', trigger: 'quote_approved' },
+    { title: 'Role upgrade approved', trigger: 'role_upgrade_approved' },
+    { title: 'Appointment booked', trigger: 'appointment_booked' },
+  ] as const
+).map(({ title, trigger }) => ({
+  title,
+  tags: getTriggerVariables(trigger).map((v) => ({
+    // In the template you reference the bare tag name; the flow's Send Email
+    // "variables" field maps it (e.g. firstName ← {{trigger.data.client_name}}).
+    tag: `{{${v.key}}}`,
+    label: v.label,
+    note: v.note,
+  })),
+}));
 
 // ── HTML email card helpers ─────────────────────────────────────────────────
 function cardHtml(imageUrl: string, title: string, subtitle: string, linkUrl = '#') {
@@ -475,6 +499,32 @@ function TagInfoPanel({ open, onClose }: { open: boolean; onClose: () => void })
               Any key–value pair passed in the <code className="bg-muted px-1 rounded">variables</code> field
               of the send API call can be used as <code className="bg-muted px-1 rounded">{'{{variableName}}'}</code>.
             </p>
+          </div>
+
+          {/* Platform / flow event tags — available when this template is sent
+              by a Flow's Send Email action (Admin → Flows). */}
+          <div className="pt-2">
+            <p className="text-xs font-semibold mb-1">Platform event tags</p>
+            <p className="text-[11px] text-muted-foreground leading-relaxed mb-3">
+              When a <strong>Flow</strong> sends this template (Admin → Flows → Send Email action), it maps
+              these into the template's <code className="bg-muted px-1 rounded">variables</code>. Grouped by the
+              event that triggers the email.
+            </p>
+            <div className="space-y-4">
+              {FLOW_EVENT_TAG_GROUPS.map((group) => (
+                <div key={group.title} className="space-y-2">
+                  <Badge variant="secondary" className="text-xs">{group.title}</Badge>
+                  {group.tags.map((t) => (
+                    <div key={t.tag} className="border rounded-lg p-2.5 space-y-1">
+                      <code className="text-xs font-mono bg-muted px-2 py-0.5 rounded text-primary font-semibold">{t.tag}</code>
+                      <p className="text-[11px] text-muted-foreground leading-relaxed">
+                        <span className="text-foreground font-medium">{t.label}</span> — {t.note}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </SheetContent>

--- a/src/modules/email/pages/EmailTemplateBuilderPage.tsx
+++ b/src/modules/email/pages/EmailTemplateBuilderPage.tsx
@@ -19,7 +19,7 @@ import { Badge } from '@/components/core/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { getProductName, getMaterialCategory, getAvailableColors } from '@/utils/productMetadata';
-import { getTriggerVariables } from '@/services/flows/triggerVariables';
+import { getAllTriggerGroups } from '@/services/flows/triggerVariables';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 type DeviceView = 'desktop' | 'tablet' | 'mobile';
@@ -51,24 +51,19 @@ const TEMPLATE_TAGS = [
 // Platform/flow event tags: when this template is sent by a Flow's "Send Email"
 // action, the flow maps these into the template's variables. Grouped by the
 // event that triggers them so authors know which tags are available per source.
-// Derived from the shared trigger-variable catalog (single source of truth).
-const FLOW_EVENT_TAG_GROUPS: Array<{ title: string; tags: Array<{ tag: string; label: string; note: string }> }> = (
-  [
-    { title: 'Project invitation', trigger: 'project_invitation_sent' },
-    { title: 'Quote accepted', trigger: 'quote_approved' },
-    { title: 'Role upgrade approved', trigger: 'role_upgrade_approved' },
-    { title: 'Appointment booked', trigger: 'appointment_booked' },
-  ] as const
-).map(({ title, trigger }) => ({
-  title,
-  tags: getTriggerVariables(trigger).map((v) => ({
-    // In the template you reference the bare tag name; the flow's Send Email
-    // "variables" field maps it (e.g. firstName ← {{trigger.data.client_name}}).
-    tag: `{{${v.key}}}`,
-    label: v.label,
-    note: v.note,
-  })),
-}));
+// Shows ALL documented event sources, derived from the shared catalog (single
+// source of truth).
+const FLOW_EVENT_TAG_GROUPS: Array<{ title: string; tags: Array<{ tag: string; label: string; note: string }> }> =
+  getAllTriggerGroups().map((group) => ({
+    title: group.title,
+    tags: group.variables.map((v) => ({
+      // In the template you reference the bare tag name; the flow's Send Email
+      // "variables" field maps it (e.g. firstName ← {{trigger.data.client_name}}).
+      tag: `{{${v.key}}}`,
+      label: v.label,
+      note: v.note,
+    })),
+  }));
 
 // ── HTML email card helpers ─────────────────────────────────────────────────
 function cardHtml(imageUrl: string, title: string, subtitle: string, linkUrl = '#') {
@@ -508,21 +503,26 @@ function TagInfoPanel({ open, onClose }: { open: boolean; onClose: () => void })
             <p className="text-[11px] text-muted-foreground leading-relaxed mb-3">
               When a <strong>Flow</strong> sends this template (Admin → Flows → Send Email action), it maps
               these into the template's <code className="bg-muted px-1 rounded">variables</code>. Grouped by the
-              event that triggers the email.
+              event that triggers the email — click an event to expand its tags.
             </p>
-            <div className="space-y-4">
+            <div className="space-y-2">
               {FLOW_EVENT_TAG_GROUPS.map((group) => (
-                <div key={group.title} className="space-y-2">
-                  <Badge variant="secondary" className="text-xs">{group.title}</Badge>
-                  {group.tags.map((t) => (
-                    <div key={t.tag} className="border rounded-lg p-2.5 space-y-1">
-                      <code className="text-xs font-mono bg-muted px-2 py-0.5 rounded text-primary font-semibold">{t.tag}</code>
-                      <p className="text-[11px] text-muted-foreground leading-relaxed">
-                        <span className="text-foreground font-medium">{t.label}</span> — {t.note}
-                      </p>
-                    </div>
-                  ))}
-                </div>
+                <details key={group.title} className="border rounded-lg bg-background/40">
+                  <summary className="cursor-pointer select-none px-3 py-2 flex items-center justify-between gap-2">
+                    <span className="text-xs font-medium">{group.title}</span>
+                    <Badge variant="outline" className="text-[10px] h-4 px-1">{group.tags.length}</Badge>
+                  </summary>
+                  <div className="px-3 pb-3 space-y-2">
+                    {group.tags.map((t) => (
+                      <div key={t.tag} className="border rounded-md p-2 space-y-1">
+                        <code className="text-xs font-mono bg-muted px-2 py-0.5 rounded text-primary font-semibold">{t.tag}</code>
+                        <p className="text-[11px] text-muted-foreground leading-relaxed">
+                          <span className="text-foreground font-medium">{t.label}</span> — {t.note}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </details>
               ))}
             </div>
           </div>

--- a/src/services/flows/triggerVariables.ts
+++ b/src/services/flows/triggerVariables.ts
@@ -1,0 +1,209 @@
+/**
+ * Trigger variable catalog
+ *
+ * Single source of truth for the `{{trigger.data.*}}` variables each flow
+ * trigger emits. Powers two surfaces:
+ *  - The flow builder's "Available variables" helper (click-to-insert into an
+ *    action's config fields).
+ *  - The email template builder's tag reference (so template authors know which
+ *    platform/flow tags they can use).
+ *
+ * Keep this in sync with the actual `emit()` / `emitFlowEvent()` payloads in the
+ * source code. When you add a converted event (see docs/flows-notification-system.md
+ * §8), add its variables here too.
+ */
+
+export interface TriggerVariable {
+  /** Field name under trigger.data — referenced as {{trigger.data.<key>}}. */
+  key: string;
+  /** Human label. */
+  label: string;
+  /** Short description of the value. */
+  note: string;
+  /** Example value. */
+  example?: string;
+}
+
+export interface TriggerVariableGroup {
+  /** The trigger_type this set of variables belongs to. */
+  trigger: string;
+  /** Display title for the group. */
+  title: string;
+  variables: TriggerVariable[];
+}
+
+// Every converted notification/email event emits this standard envelope. The
+// recipient + display strings are built in the source at emit time.
+const STANDARD: TriggerVariable[] = [
+  { key: 'user_id', label: 'Recipient user ID', note: 'The user who receives the notification.', example: 'a1b2c3d4-…' },
+  { key: 'title', label: 'Title', note: 'Pre-built notification/email title.', example: 'Your VR world is ready!' },
+  { key: 'body', label: 'Body', note: 'Pre-built notification/email body text.', example: 'Your 3D environment has been generated.' },
+  { key: 'action_url', label: 'Action URL', note: 'Where the notification deep-links to.', example: '/profile?tab=inbox' },
+  { key: 'type', label: 'Type', note: 'Notification type / category key.', example: 'vr_world_ready' },
+];
+
+// Helper: standard envelope + event-specific extras.
+const withStandard = (extra: TriggerVariable[]): TriggerVariable[] => [...STANDARD, ...extra];
+
+/**
+ * Per-trigger variables. Triggers not listed here either carry no structured
+ * payload or only the standard envelope; callers fall back to STANDARD_VARIABLES.
+ */
+export const TRIGGER_VARIABLES: Record<string, TriggerVariable[]> = {
+  hire_me_received: withStandard([
+    { key: 'from_name', label: 'Sender name', note: 'Name of the person sending the hire request.' },
+    { key: 'from_email', label: 'Sender email', note: 'Email of the person sending the hire request.' },
+    { key: 'services_requested', label: 'Services', note: 'Array of requested service names.' },
+  ]),
+  profile_followed: withStandard([
+    { key: 'follower_id', label: 'Follower ID', note: 'The user who started following.' },
+    { key: 'following_id', label: 'Followed ID', note: 'The profile being followed.' },
+  ]),
+  material_reviewed: withStandard([
+    { key: 'product_id', label: 'Product ID', note: 'The reviewed material.' },
+    { key: 'reviewer_id', label: 'Reviewer ID', note: 'Who left the review.' },
+    { key: 'owner_user_id', label: 'Owner ID', note: 'The material owner (recipient).' },
+    { key: 'rating', label: 'Rating', note: 'Star rating left.', example: '5' },
+  ]),
+  preferred_factory_added: withStandard([
+    { key: 'factory_user_id', label: 'Factory user ID', note: 'The verified factory user (recipient).' },
+    { key: 'factory_name', label: 'Factory name', note: 'The added factory name.' },
+  ]),
+  vr_world_created: withStandard([
+    { key: 'world_id', label: 'World ID', note: 'The generated VR world.' },
+    { key: 'quality_tier', label: 'Quality tier', note: 'The model/quality used.' },
+  ]),
+  vr_world_failed: withStandard([{ key: 'world_id', label: 'World ID', note: 'The VR world that failed.' }]),
+  virtual_staging_completed: withStandard([
+    { key: 'job_id', label: 'Job ID', note: 'The staging job.' },
+    { key: 'room', label: 'Room', note: 'The staged room type.' },
+  ]),
+  video_generation_completed: withStandard([
+    { key: 'job_id', label: 'Job ID', note: 'The video job.' },
+    { key: 'video_type', label: 'Video type', note: 'The kind of video generated.' },
+  ]),
+  video_generation_failed: withStandard([
+    { key: 'job_id', label: 'Job ID', note: 'The video job that failed.' },
+    { key: 'video_type', label: 'Video type', note: 'The kind of video attempted.' },
+  ]),
+  svbrdf_extraction_complete: withStandard([
+    { key: 'extraction_id', label: 'Extraction ID', note: 'The SVBRDF extraction job.' },
+  ]),
+  agent_search_completed: withStandard([
+    { key: 'agent_id', label: 'Agent ID', note: 'The background agent.' },
+    { key: 'run_id', label: 'Run ID', note: 'The agent run.' },
+  ]),
+  background_agent_failed: withStandard([
+    { key: 'agent_id', label: 'Agent ID', note: 'The background agent.' },
+    { key: 'run_id', label: 'Run ID', note: 'The failed agent run.' },
+  ]),
+  role_upgrade_request_submitted: withStandard([
+    { key: 'requested_role', label: 'Requested role', note: 'The role applied for.' },
+  ]),
+  role_upgrade_approved: withStandard([
+    { key: 'request_id', label: 'Request ID', note: 'The upgrade request.' },
+    { key: 'requested_role', label: 'Requested role', note: 'The granted role.' },
+  ]),
+  role_upgrade_rejected: withStandard([
+    { key: 'request_id', label: 'Request ID', note: 'The upgrade request.' },
+    { key: 'requested_role', label: 'Requested role', note: 'The rejected role.' },
+  ]),
+  factory_approved: withStandard([
+    { key: 'request_id', label: 'Request ID', note: 'The verification request.' },
+    { key: 'company_name', label: 'Company name', note: 'The approved supplier.' },
+  ]),
+  factory_rejected: withStandard([
+    { key: 'request_id', label: 'Request ID', note: 'The verification request.' },
+    { key: 'company_name', label: 'Company name', note: 'The rejected supplier.' },
+  ]),
+  appointment_booked: withStandard([
+    { key: 'appointment_id', label: 'Appointment ID', note: 'The booking.' },
+    { key: 'professional_user_id', label: 'Professional ID', note: 'The professional (recipient).' },
+    { key: 'client_name', label: 'Client name', note: 'Who booked.' },
+    { key: 'client_email', label: 'Client email', note: 'Client contact.' },
+    { key: 'date', label: 'Date', note: 'Appointment date.' },
+    { key: 'time', label: 'Time', note: 'Appointment time slot.' },
+    { key: 'service_name', label: 'Service', note: 'Booked service.' },
+  ]),
+  appointment_confirmed: withStandard([
+    { key: 'appointment_id', label: 'Appointment ID', note: 'The booking.' },
+    { key: 'professional_user_id', label: 'Professional ID', note: 'The professional.' },
+  ]),
+  appointment_cancelled: withStandard([
+    { key: 'appointment_id', label: 'Appointment ID', note: 'The booking.' },
+    { key: 'professional_user_id', label: 'Professional ID', note: 'The professional.' },
+  ]),
+  quote_approved: [
+    { key: 'admin_ids', label: 'Admin IDs', note: 'Array of workspace admins to notify — iterate with a Loop ({{item}} = each admin id).' },
+    { key: 'quote_id', label: 'Quote ID', note: 'The accepted quote.' },
+    { key: 'user_id', label: 'Quote owner', note: 'The quote owner.' },
+    { key: 'title', label: 'Title', note: 'Pre-built notification title.' },
+    { key: 'body', label: 'Body', note: 'Pre-built notification body.' },
+    { key: 'action_url', label: 'Action URL', note: 'Deep link to the quote.' },
+    { key: 'type', label: 'Type', note: 'Notification type.' },
+  ],
+  quote_rejected: [
+    { key: 'admin_ids', label: 'Admin IDs', note: 'Array of workspace admins to notify — iterate with a Loop ({{item}} = each admin id).' },
+    { key: 'quote_id', label: 'Quote ID', note: 'The declined quote.' },
+    { key: 'user_id', label: 'Quote owner', note: 'The quote owner.' },
+    { key: 'title', label: 'Title', note: 'Pre-built notification title.' },
+    { key: 'body', label: 'Body', note: 'Pre-built notification body.' },
+    { key: 'action_url', label: 'Action URL', note: 'Deep link to the quote.' },
+    { key: 'type', label: 'Type', note: 'Notification type.' },
+  ],
+  quote_pdf_generated: withStandard([{ key: 'quote_id', label: 'Quote ID', note: 'The quote whose PDF is ready.' }]),
+  stripe_payment_succeeded: withStandard([
+    { key: 'credit_amount', label: 'Credit amount', note: 'Credits added.' },
+    { key: 'payment_intent_id', label: 'Payment intent ID', note: 'The Stripe payment intent.' },
+  ]),
+  stripe_payment_failed: withStandard([
+    { key: 'payment_intent_id', label: 'Payment intent ID', note: 'The failed Stripe payment intent.' },
+  ]),
+  // Email events — emit `to`/`subject`/`body` rather than a notification envelope.
+  project_invitation_sent: [
+    { key: 'to', label: 'Recipient email', note: 'Invitee email address.' },
+    { key: 'subject', label: 'Subject', note: 'Pre-built email subject.' },
+    { key: 'body', label: 'Body (HTML)', note: 'Pre-rendered invite email HTML.' },
+    { key: 'project_id', label: 'Project ID', note: 'The project.' },
+    { key: 'project_name', label: 'Project name', note: 'The project name.' },
+    { key: 'inviter_name', label: 'Inviter name', note: 'Who sent the invite.' },
+  ],
+  project_invitation_resent: [
+    { key: 'to', label: 'Recipient email', note: 'Invitee email address.' },
+    { key: 'subject', label: 'Subject', note: 'Pre-built email subject.' },
+    { key: 'body', label: 'Body (HTML)', note: 'Pre-rendered invite email HTML.' },
+    { key: 'project_id', label: 'Project ID', note: 'The project.' },
+    { key: 'project_name', label: 'Project name', note: 'The project name.' },
+    { key: 'inviter_name', label: 'Inviter name', note: 'Who sent the invite.' },
+  ],
+  // Infrastructure triggers
+  webhook: [
+    { key: 'any field from the POST body', label: 'Webhook body', note: 'Whatever JSON the external caller POSTs becomes trigger.data.*' },
+    { key: '_webhook.method', label: 'HTTP method', note: 'The request method.' },
+    { key: '_webhook.query_params', label: 'Query params', note: 'URL query parameters as an object.' },
+  ],
+  scheduled: [
+    { key: 'scheduled', label: 'Scheduled flag', note: 'Always true on a scheduled run.' },
+    { key: 'cron', label: 'Cron expression', note: 'The schedule that fired.' },
+    { key: 'timestamp', label: 'Fire time', note: 'ISO timestamp of the run.' },
+  ],
+};
+
+/** The standard envelope every notification/email event carries. */
+export const STANDARD_VARIABLES = STANDARD;
+
+/** Loop-scoped variables, available inside a Loop's downstream action. */
+export const LOOP_VARIABLES: TriggerVariable[] = [
+  { key: 'item', label: 'Loop item', note: 'The current item from the collection. Use {{item}} or {{item.field}}.' },
+  { key: 'loop_index', label: 'Loop index', note: 'Zero-based index of the current iteration.' },
+];
+
+/**
+ * Returns the variables for a trigger as ready-to-paste template strings, e.g.
+ * { token: '{{trigger.data.title}}', label: 'Title', note: '…' }.
+ * Falls back to the standard envelope for unknown/payload-less triggers.
+ */
+export function getTriggerVariables(trigger: string | undefined): Array<TriggerVariable & { token: string }> {
+  const vars = (trigger && TRIGGER_VARIABLES[trigger]) || STANDARD;
+  return vars.map((v) => ({ ...v, token: `{{trigger.data.${v.key}}}` }));
+}

--- a/src/services/flows/triggerVariables.ts
+++ b/src/services/flows/triggerVariables.ts
@@ -207,3 +207,51 @@ export function getTriggerVariables(trigger: string | undefined): Array<TriggerV
   const vars = (trigger && TRIGGER_VARIABLES[trigger]) || STANDARD;
   return vars.map((v) => ({ ...v, token: `{{trigger.data.${v.key}}}` }));
 }
+
+/** Human display title for every trigger that has a documented payload. */
+export const TRIGGER_TITLES: Record<string, string> = {
+  hire_me_received: 'Hire Me request',
+  profile_followed: 'New follower',
+  material_reviewed: 'Material reviewed',
+  preferred_factory_added: 'Preferred factory added',
+  vr_world_created: 'VR world ready',
+  vr_world_failed: 'VR world failed',
+  virtual_staging_completed: 'Virtual staging ready',
+  video_generation_completed: 'Video generated',
+  video_generation_failed: 'Video failed',
+  svbrdf_extraction_complete: 'SVBRDF maps ready',
+  agent_search_completed: 'Agent run completed',
+  background_agent_failed: 'Agent run failed',
+  role_upgrade_request_submitted: 'Role upgrade requested',
+  role_upgrade_approved: 'Role upgrade approved',
+  role_upgrade_rejected: 'Role upgrade rejected',
+  factory_approved: 'Factory approved',
+  factory_rejected: 'Factory rejected',
+  appointment_booked: 'Appointment booked',
+  appointment_confirmed: 'Appointment confirmed',
+  appointment_cancelled: 'Appointment cancelled',
+  quote_approved: 'Quote accepted',
+  quote_rejected: 'Quote declined',
+  quote_pdf_generated: 'Quote PDF ready',
+  stripe_payment_succeeded: 'Payment succeeded',
+  stripe_payment_failed: 'Payment failed',
+  project_invitation_sent: 'Project invite sent',
+  project_invitation_resent: 'Project invite resent',
+  webhook: 'Webhook (external)',
+  scheduled: 'Scheduled (cron)',
+};
+
+/**
+ * All documented event sources as { title, trigger, variables } groups, ordered
+ * by TRIGGER_TITLES. Used by the email template builder's tag reference so an
+ * author can see every event whose data a flow can map into a template.
+ */
+export function getAllTriggerGroups(): Array<{ trigger: string; title: string; variables: Array<TriggerVariable & { token: string }> }> {
+  return Object.keys(TRIGGER_TITLES)
+    .filter((t) => TRIGGER_VARIABLES[t]) // only triggers with a documented payload
+    .map((trigger) => ({
+      trigger,
+      title: TRIGGER_TITLES[trigger],
+      variables: getTriggerVariables(trigger),
+    }));
+}

--- a/src/services/flows/types.ts
+++ b/src/services/flows/types.ts
@@ -319,6 +319,8 @@ export interface SendEmailConfig {
   body: string;
   template_id?: string;
   from?: string;
+  /** JSON object mapping email-template {{tag}} names → values (values may use {{trigger.data.*}}). */
+  variables?: string;
 }
 
 export interface SendPushConfig {

--- a/supabase/functions/flow-engine/index.ts
+++ b/supabase/functions/flow-engine/index.ts
@@ -255,6 +255,20 @@ async function executeAction(
       if (!emailTo || emailTo.includes('{{')) {
         return { output: { skipped: true, reason: 'unresolved_to' } };
       }
+      // `variables` lets a flow fill an email template's {{tag}} placeholders.
+      // The config holds it as a JSON object (templated values already resolved
+      // by resolveAllTemplates), so an operator can map trigger.data → template tags.
+      let emailVariables: Record<string, unknown> | undefined;
+      if (resolved.variables && typeof resolved.variables === 'object') {
+        emailVariables = resolved.variables as Record<string, unknown>;
+      } else if (typeof resolved.variables === 'string' && resolved.variables.trim()) {
+        try {
+          emailVariables = JSON.parse(resolved.variables);
+        } catch {
+          // leave undefined — a malformed map shouldn't block the send
+        }
+      }
+
       const { data, error } = await supabase.functions.invoke('email-api', {
         body: {
           action: 'send',
@@ -262,7 +276,10 @@ async function executeAction(
           from: resolved.from || undefined,
           subject: resolved.subject,
           html: resolved.body,
-          template_id: resolved.template_id || undefined,
+          // email-api expects templateSlug (not template_id); template fields
+          // (subject/body) are rendered from `variables` server-side.
+          templateSlug: resolved.template_id || resolved.template_slug || undefined,
+          variables: emailVariables,
         },
       });
       if (error) throw new Error(`Email failed: ${error.message}`);


### PR DESCRIPTION
## Why

Two gaps from the flows review:
1. The flow editor never told operators **which `{{trigger.data.*}}` variables** an action could use — you had to read source code.
2. Flow-triggered **template emails couldn't fill `{{tag}}` placeholders** (the `send_email` action sent the wrong param name and no variables map).
3. Email template authors had no way to know which **platform/flow tags** are available.

## What's in it

### Shared catalog — `src/services/flows/triggerVariables.ts`
Single source of truth mapping every trigger → its `trigger.data.*` fields (label + note), plus loop / webhook / scheduled vars. Both surfaces below read from it, so they never drift.

### Flow editor — "Available variables" helper
New `VariablesHelper`: a collapsible panel in the node config sidebar (for action/condition nodes) listing the flow trigger's variables with **click-to-copy** `{{trigger.data.…}}` tokens. Adds `{{item}}`/`{{loop_index}}` when the node is downstream of a Loop. Notes that **plain text overrides** the source value while `{{…}}` is filled at runtime.

### Flow `send_email` — template variables wired (was doubly broken)
- The engine sent `template_id`, but email-api expects **`templateSlug`** → fixed.
- It passed **no `variables`** → template `{{tag}}`s never filled. Now passes a resolved `variables` map.
- New optional **"Template variables (JSON)"** field in the action config (+ `SendEmailConfig.variables`), so operators map `{{tag}}` ← `{{trigger.data.*}}`.

### Email builder — platform event tags
`TagInfoPanel` now also shows a **"Platform event tags"** section grouped by event (project invite / quote accepted / role upgrade / appointment), derived from the shared catalog — so template authors know which tags a flow can supply.

## Notes
- The flow editor helper shows variables; **plain text in a field overrides** what the source emits (engine only substitutes `{{…}}`).
- Typecheck clean (0 errors). Isolated worktree; no other working-tree changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)