### PR TITLE
2026 command-center redesign — global design language (one revertible PR)

### DIFF
--- a/src/components/core/DesignSystem/KpiCard.tsx
+++ b/src/components/core/DesignSystem/KpiCard.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { cn } from '@/lib/utils';
+
+import { Metric, type MetricSize } from './Metric';
+import { MicroLabel, DeltaChip, CircleAction, type DeltaDirection } from './MetricParts';
+
+export interface ComparePeriod {
+  /** Caption above the bar, e.g. "Last Month". */
+  label: string;
+  /** 0–1, relative to the larger of the two periods. */
+  ratio: number;
+}
+
+interface KpiCardProps {
+  label: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  /** Formatted headline value. */
+  value: string;
+  size?: MetricSize;
+  delta?: { label: string; direction: DeltaDirection };
+  /** The hatched "previous" bar and solid "current" bar beneath the number. */
+  compare?: { previous: ComparePeriod; current: ComparePeriod };
+  /** Target for the corner circle-action. */
+  to?: string;
+  /** Plain caption under the number when there is no compare pair. */
+  caption?: string;
+  className?: string;
+}
+
+/**
+ * KpiCard — the headline metric card: micro-label, oversized two-tone numeral,
+ * and a hatched-vs-solid period comparison.
+ *
+ * The comparison bars are the part that carries meaning the number alone cannot:
+ * a stripe pattern reads as "historic" and a solid fill as "current" without a
+ * legend, so the card answers "is this good?" at a glance.
+ */
+export const KpiCard: React.FC<KpiCardProps> = ({
+  label,
+  icon: Icon,
+  value,
+  size = 'lg',
+  delta,
+  compare,
+  to,
+  caption,
+  className,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className={cn('surface-raised p-5 sm:p-6 flex flex-col', className)}>
+      <div className="flex items-start justify-between gap-3">
+        <MicroLabel icon={Icon}>{label}</MicroLabel>
+        {to && <CircleAction label={`Open ${label}`} onClick={() => navigate(to)} />}
+      </div>
+
+      <div className="mt-4 flex items-end gap-2 flex-wrap">
+        <Metric value={value} size={size} />
+        {delta && <DeltaChip label={delta.label} direction={delta.direction} showIcon className="mb-1.5" />}
+      </div>
+
+      {compare ? (
+        <div className="mt-6 grid grid-cols-2 gap-3 items-end">
+          <div>
+            <p className="text-[10px] text-muted-foreground mb-1.5 truncate">{compare.previous.label}</p>
+            <div
+              className="hatch-bar"
+              style={{ height: `${Math.max(10, compare.previous.ratio * 44)}px` }}
+            />
+          </div>
+          <div>
+            <p className="text-[10px] text-muted-foreground mb-1.5 truncate">{compare.current.label}</p>
+            <div
+              className={cn(
+                'rounded-md flex items-center justify-center',
+                delta?.direction === 'down' ? 'bg-error/70' : 'bg-vivid',
+              )}
+              style={{ height: `${Math.max(10, compare.current.ratio * 44)}px` }}
+            >
+              {delta && (
+                <span
+                  className={cn(
+                    'text-[10px] font-semibold px-1.5 py-0.5 rounded-full',
+                    delta.direction === 'down'
+                      ? 'bg-black/25 text-white'
+                      : 'bg-black/15 text-vivid-foreground',
+                  )}
+                >
+                  {delta.label}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : (
+        caption && <p className="mt-4 text-xs text-muted-foreground">{caption}</p>
+      )}
+    </div>
+  );
+};

--- a/src/components/core/DesignSystem/MeshCard.tsx
+++ b/src/components/core/DesignSystem/MeshCard.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { cn } from '@/lib/utils';
+
+import { CircleAction } from './MetricParts';
+
+interface MeshCardProps {
+  /** Small caption in the top-left, e.g. "Insights". */
+  eyebrow?: string;
+  /** The headline. Kept as a node so a value can be emphasised inline. */
+  children: React.ReactNode;
+  to?: string;
+  /** Dot pager along the top-right, as in the reference. */
+  pager?: { count: number; active: number };
+  className?: string;
+}
+
+/**
+ * MeshCard — the single saturated surface on a screen.
+ *
+ * Both reference dashboards keep exactly ONE loud blurred-gradient panel and let
+ * everything else stay quiet; that restraint is what makes it read as a focal
+ * point. Rendering two on one view defeats the purpose.
+ */
+export const MeshCard: React.FC<MeshCardProps> = ({
+  eyebrow,
+  children,
+  to,
+  pager,
+  className,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className={cn('mesh-card p-6 flex flex-col justify-between min-h-[15rem]', className)}>
+      <div className="flex items-start justify-between gap-4">
+        {eyebrow && (
+          <span className="text-xs uppercase tracking-[0.09em] font-semibold text-white/85">
+            {eyebrow}
+          </span>
+        )}
+        {pager && pager.count > 1 && (
+          <div className="flex items-center gap-1.5 pt-1" aria-hidden="true">
+            {Array.from({ length: pager.count }).map((_, i) => (
+              <span
+                key={i}
+                className={cn(
+                  'h-0.5 rounded-full transition-all',
+                  i === pager.active ? 'w-5 bg-white' : 'w-3 bg-white/40',
+                )}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-8 flex items-end justify-between gap-4">
+        <div className="text-2xl sm:text-[1.75rem] leading-[1.15] font-display text-white drop-shadow-sm">
+          {children}
+        </div>
+        {to && (
+          <CircleAction
+            label="Open insight"
+            onClick={() => navigate(to)}
+            className="border-white/45 text-white hover:bg-white hover:border-white hover:text-black"
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/core/DesignSystem/Metric.tsx
+++ b/src/components/core/DesignSystem/Metric.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type MetricSize = 'sm' | 'md' | 'lg' | 'xl';
+
+const SIZE_CLASS: Record<MetricSize, string> = {
+  sm: 'metric-sm',
+  md: 'metric-md',
+  lg: 'metric-lg',
+  xl: 'metric-xl',
+};
+
+interface MetricProps {
+  /** Already-formatted display value, e.g. "€23,876" or "32.5%". Format upstream —
+   *  this component NEVER derives or rounds a number, it only sets type. */
+  value: string;
+  size?: MetricSize;
+  /** Two-tone split. 'auto' greys the final group (",876" of "23,876"), which is
+   *  what makes the magnitude land first. 'none' renders one flat tone. */
+  split?: 'auto' | 'none';
+  className?: string;
+}
+
+/** A currency mark / unit that should ride small and high rather than at numeral size. */
+const AFFIX_RE = /^([^\d\-+.]*)(.*?)([^\d]*)$/s;
+
+/** Split a formatted number into { prefix, lead, trail, suffix }.
+ *
+ *  The reference dashboards grey the LAST group only — "$ 170,024" sets "170"
+ *  at full weight and ",024" muted — so the split point is the final separator
+ *  followed by digits, not the first one. */
+export function splitMetric(value: string): {
+  prefix: string;
+  lead: string;
+  trail: string;
+  suffix: string;
+} {
+  const m = AFFIX_RE.exec(value);
+  const prefix = m?.[1] ?? '';
+  const body = m?.[2] ?? value;
+  const suffix = m?.[3] ?? '';
+
+  // Final separator + trailing digit group (thousands tail or decimals).
+  const sep = /[.,](\d+)$/.exec(body);
+  if (!sep || sep.index <= 0) {
+    return { prefix, lead: body, trail: '', suffix };
+  }
+  return {
+    prefix,
+    lead: body.slice(0, sep.index),
+    trail: body.slice(sep.index),
+    suffix,
+  };
+}
+
+/**
+ * Metric — the oversized two-tone numeral.
+ *
+ * This is the centrepiece of the 2026 command-center language. Before it, the
+ * platform had no type tier above 36px, so a KPI and a table cell carried the
+ * same visual weight and nothing on a screen led the eye.
+ *
+ * Usage:
+ *   <Metric value={formatMoney(total, 'EUR', { decimals: 0 })} size="lg" />
+ */
+export const Metric: React.FC<MetricProps> = ({
+  value,
+  size = 'md',
+  split = 'auto',
+  className,
+}) => {
+  const { prefix, lead, trail, suffix } = React.useMemo(
+    () => (split === 'auto' ? splitMetric(value) : { prefix: '', lead: value, trail: '', suffix: '' }),
+    [value, split],
+  );
+
+  return (
+    <span className={cn('metric', SIZE_CLASS[size], className)}>
+      {prefix && <span className="metric-affix">{prefix}</span>}
+      <span>{lead}</span>
+      {trail && <span className="metric-trail">{trail}</span>}
+      {suffix && <span className="metric-affix">{suffix}</span>}
+    </span>
+  );
+};

--- a/src/components/core/DesignSystem/MetricParts.tsx
+++ b/src/components/core/DesignSystem/MetricParts.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { ArrowUpRight, ArrowDown, ArrowUp, Minus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+/* ────────────────────────────────────────────────────────────────────────────
+   The small parts a metric is assembled from. Each is deliberately dumb — they
+   take formatted strings and render type. No derivation happens here (money
+   quantities derive in SQL; see CLAUDE.md "One derivation per money quantity").
+   ──────────────────────────────────────────────────────────────────────────── */
+
+/** MicroLabel — the tiny uppercase caption above a metric. */
+export const MicroLabel: React.FC<{
+  children: React.ReactNode;
+  icon?: React.ComponentType<{ className?: string }>;
+  className?: string;
+}> = ({ children, icon: Icon, className }) => (
+  <span className={cn('micro-label', className)}>
+    {Icon && <Icon className="h-3 w-3 shrink-0" />}
+    {children}
+  </span>
+);
+
+export type DeltaDirection = 'up' | 'down' | 'flat';
+
+/** Resolve the visual direction of a change.
+ *
+ *  `inverted` matters: for "overdue invoices" or "churn risk" a RISE is bad, so
+ *  the chip must go red on an increase. Getting this wrong paints a worsening
+ *  number in the positive accent, which is worse than no chip at all. */
+export function deltaDirection(change: number, inverted = false): DeltaDirection {
+  if (change === 0) return 'flat';
+  const rising = change > 0;
+  if (inverted) return rising ? 'down' : 'up';
+  return rising ? 'up' : 'down';
+}
+
+/** DeltaChip — the small +2 / −12% marker riding beside a metric. */
+export const DeltaChip: React.FC<{
+  /** Pre-formatted label, e.g. "+2" or "−12%". */
+  label: string;
+  direction: DeltaDirection;
+  showIcon?: boolean;
+  className?: string;
+}> = ({ label, direction, showIcon = false, className }) => {
+  const Icon = direction === 'up' ? ArrowUp : direction === 'down' ? ArrowDown : Minus;
+  return (
+    <span
+      className={cn(
+        'delta-chip',
+        direction === 'up' && 'delta-up',
+        direction === 'down' && 'delta-down',
+        direction === 'flat' && 'delta-flat',
+        className,
+      )}
+    >
+      {showIcon && <Icon className="h-2.5 w-2.5" />}
+      {label}
+    </span>
+  );
+};
+
+/** Meter — track + fill + dot marker beneath a KPI. */
+export const Meter: React.FC<{
+  /** 0–1. Clamped, so an out-of-range ratio can never overflow the track. */
+  value: number;
+  /** Draw the dot marker at the fill head. */
+  marker?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}> = ({ value, marker = true, className, 'aria-label': ariaLabel }) => {
+  const pct = Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0)) * 100;
+  return (
+    <div
+      className={cn('meter-track', className)}
+      role="progressbar"
+      aria-valuenow={Math.round(pct)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={ariaLabel}
+    >
+      <div className="meter-fill" style={{ width: `${pct}%` }} />
+      {marker && <div className="meter-dot" style={{ left: `${pct}%` }} />}
+    </div>
+  );
+};
+
+/** CircleAction — the round "open this" affordance in a card corner. */
+export const CircleAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement> & { label: string }
+>(({ label, className, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    aria-label={label}
+    title={label}
+    className={cn('circle-action', className)}
+    {...props}
+  >
+    {/* The button rotates 45° on hover (see `.circle-action:hover`), which swings
+        this arrow from up-right to straight-right — a "go there" cue for free. */}
+    <ArrowUpRight className="h-4 w-4" />
+  </button>
+));
+CircleAction.displayName = 'CircleAction';

--- a/src/components/core/DesignSystem/NotchPanel.tsx
+++ b/src/components/core/DesignSystem/NotchPanel.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface NotchPanelProps {
+  /** Tab label — Title Case, it reads as a section heading. */
+  title: string;
+  /** Count bubble inside the tab. */
+  count?: number;
+  /** Rendered inline to the right of the tab, outside the panel (filters etc). */
+  toolbar?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * NotchPanel — the folder-tab section container.
+ *
+ * The tab and the panel share one recessed surface joined by a concave corner
+ * (carved by a radial mask in `.tab-notch::after`). It groups a row of tiles
+ * into one labelled region, which is the job the platform previously did with
+ * yet another identical glass card — so a group of stats and a single stat
+ * looked the same.
+ */
+export const NotchPanel: React.FC<NotchPanelProps> = ({
+  title,
+  count,
+  toolbar,
+  children,
+  className,
+}) => (
+  <section className={cn('w-full', className)}>
+    <div className="flex items-end gap-3 flex-wrap">
+      <div className="tab-notch">
+        {typeof count === 'number' && (
+          <span className="flex h-6 min-w-6 items-center justify-center rounded-full bg-vivid px-1.5 text-xs font-semibold text-vivid-foreground">
+            {count}
+          </span>
+        )}
+        <h2 className="text-base font-semibold tracking-tight">{title}</h2>
+      </div>
+      {toolbar && <div className="flex items-center gap-2 pb-3 ml-auto">{toolbar}</div>}
+    </div>
+
+    <div className="tab-notch-panel p-4 sm:p-6">{children}</div>
+  </section>
+);
+
+/**
+ * NotchGroup — a labelled column of tiles inside a NotchPanel, separated from
+ * its neighbour by a hairline rather than another card border.
+ */
+export const NotchGroup: React.FC<{
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}> = ({ label, children, className }) => (
+  <div className={cn('min-w-0', className)}>
+    <p className="text-sm text-muted-foreground mb-3">{label}</p>
+    {children}
+  </div>
+);

--- a/src/components/core/DesignSystem/QuickActions.tsx
+++ b/src/components/core/DesignSystem/QuickActions.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Plus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export interface QuickAction {
+  label: string;
+  to: string;
+  /** Optional leading icon; defaults to the "+" affordance from the reference. */
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+interface QuickActionsProps {
+  actions: QuickAction[];
+  /** Target for the trailing solid "+" button that opens the full create menu. */
+  moreTo?: string;
+  onMore?: () => void;
+  className?: string;
+}
+
+/**
+ * QuickActions — the outlined pill row of create shortcuts.
+ *
+ * Sits directly under the page title, above the metrics. Its job is to make the
+ * five things you actually start a session by doing reachable in one click,
+ * instead of buried three levels into a nav.
+ */
+export const QuickActions: React.FC<QuickActionsProps> = ({
+  actions,
+  moreTo,
+  onMore,
+  className,
+}) => (
+  <div className={cn('flex items-center gap-2 flex-wrap', className)}>
+    {actions.map((a) => {
+      const Icon = a.icon ?? Plus;
+      return (
+        <Link key={a.to + a.label} to={a.to} className="pill-action">
+          <span className="flex h-5 w-5 items-center justify-center rounded-full border border-current/25 opacity-70">
+            <Icon className="h-3 w-3" />
+          </span>
+          {a.label}
+        </Link>
+      );
+    })}
+
+    {(moreTo || onMore) &&
+      (moreTo ? (
+        <Link
+          to={moreTo}
+          aria-label="More actions"
+          title="More actions"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-foreground text-background transition-transform hover:scale-105"
+        >
+          <Plus className="h-4 w-4" />
+        </Link>
+      ) : (
+        <button
+          type="button"
+          onClick={onMore}
+          aria-label="More actions"
+          title="More actions"
+          className="flex h-9 w-9 items-center justify-center rounded-full bg-foreground text-background transition-transform hover:scale-105"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      ))}
+  </div>
+);

--- a/src/components/core/DesignSystem/Sparkline.tsx
+++ b/src/components/core/DesignSystem/Sparkline.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface SparklineProps {
+  /** Raw series, oldest → newest. Fewer than 2 points renders nothing. */
+  data: number[];
+  width?: number;
+  height?: number;
+  /** 'vivid' uses the acid data accent; 'ink' uses the foreground (the reference
+   *  draws these as thin near-black strokes on light cards). */
+  tone?: 'ink' | 'vivid';
+  /** Fill the area under the curve with a faint wash. */
+  area?: boolean;
+  className?: string;
+}
+
+/** Catmull-Rom → cubic bezier, so the line reads hand-drawn rather than jagged. */
+function smoothPath(points: Array<[number, number]>): string {
+  if (points.length < 2) return '';
+  if (points.length === 2) {
+    return `M ${points[0][0]} ${points[0][1]} L ${points[1][0]} ${points[1][1]}`;
+  }
+
+  let d = `M ${points[0][0]} ${points[0][1]}`;
+  for (let i = 0; i < points.length - 1; i++) {
+    const p0 = points[i === 0 ? 0 : i - 1];
+    const p1 = points[i];
+    const p2 = points[i + 1];
+    const p3 = points[i + 2] ?? p2;
+
+    const c1x = p1[0] + (p2[0] - p0[0]) / 6;
+    const c1y = p1[1] + (p2[1] - p0[1]) / 6;
+    const c2x = p2[0] - (p3[0] - p1[0]) / 6;
+    const c2y = p2[1] - (p3[1] - p1[1]) / 6;
+
+    d += ` C ${c1x.toFixed(2)} ${c1y.toFixed(2)}, ${c2x.toFixed(2)} ${c2y.toFixed(2)}, ${p2[0].toFixed(2)} ${p2[1].toFixed(2)}`;
+  }
+  return d;
+}
+
+/**
+ * Sparkline — the thin trend line riding beside a stat.
+ *
+ * Deliberately unlabelled and unaxised: it carries SHAPE, not value. The number
+ * next to it carries the value. Purely presentational, no data fetching.
+ */
+export const Sparkline: React.FC<SparklineProps> = ({
+  data,
+  width = 64,
+  height = 24,
+  tone = 'ink',
+  area = false,
+  className,
+}) => {
+  const path = React.useMemo(() => {
+    if (!data || data.length < 2) return { line: '', fill: '' };
+
+    const min = Math.min(...data);
+    const max = Math.max(...data);
+    // A flat series would divide by zero — pin it to the vertical centre instead.
+    const span = max - min || 1;
+    const pad = 2;
+    const innerH = height - pad * 2;
+
+    const points = data.map<[number, number]>((v, i) => [
+      (i / (data.length - 1)) * width,
+      pad + innerH - ((v - min) / span) * innerH,
+    ]);
+
+    const line = smoothPath(points);
+    const fill = line ? `${line} L ${width} ${height} L 0 ${height} Z` : '';
+    return { line, fill };
+  }, [data, width, height]);
+
+  if (!path.line) return null;
+
+  const strokeClass = tone === 'vivid' ? 'spark-stroke-vivid' : 'spark-stroke';
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      fill="none"
+      className={cn('overflow-visible', className)}
+      aria-hidden="true"
+      focusable="false"
+    >
+      {area && (
+        <path
+          d={path.fill}
+          className={tone === 'vivid' ? 'fill-vivid/12' : 'fill-foreground/8'}
+        />
+      )}
+      <path
+        d={path.line}
+        className={strokeClass}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/src/components/core/DesignSystem/StatCard.tsx
+++ b/src/components/core/DesignSystem/StatCard.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { cn } from '@/lib/utils';
 import { LucideIcon } from 'lucide-react';
 
+import { Metric } from './Metric';
+import { MicroLabel, DeltaChip } from './MetricParts';
+
 interface StatCardProps {
   title: string;
   value: string | number;
@@ -35,28 +38,27 @@ export const StatCard: React.FC<StatCardProps> = ({
 }) => {
   return (
     <div className={cn('stat-card', className)}>
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <p className="text-sm text-muted-foreground mb-2">{title}</p>
-          <p className="text-2xl font-light text-foreground">{value}</p>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          {/* Micro-label above, oversized numeral below — the order that makes a
+              number read as instrumentation. Was a 14px caption over a 24px value. */}
+          <MicroLabel className="mb-3">{title}</MicroLabel>
+          <Metric value={String(value)} size="md" />
           {change && (
-            <div className="mt-2">
-              <span
-                className={cn(
-                  'text-sm font-medium',
-                  change.type === 'increase' && 'text-success',
-                  change.type === 'decrease' && 'text-error',
-                  change.type === 'neutral' && 'text-muted-foreground',
-                )}
-              >
-                {change.value}
-              </span>
+            <div className="mt-3">
+              <DeltaChip
+                label={change.value}
+                direction={
+                  change.type === 'increase' ? 'up' : change.type === 'decrease' ? 'down' : 'flat'
+                }
+                showIcon
+              />
             </div>
           )}
         </div>
         {Icon && (
-          <div className={cn('p-3 rounded-lg bg-secondary/50', iconColor)}>
-            <Icon className="w-6 h-6" />
+          <div className={cn('p-2.5 rounded-xl bg-secondary/50 shrink-0', iconColor)}>
+            <Icon className="w-5 h-5" />
           </div>
         )}
       </div>

--- a/src/components/core/DesignSystem/StatTile.tsx
+++ b/src/components/core/DesignSystem/StatTile.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { cn } from '@/lib/utils';
+
+import { Metric } from './Metric';
+import { Sparkline } from './Sparkline';
+import { DeltaChip, type DeltaDirection } from './MetricParts';
+
+interface StatTileProps {
+  /** Formatted value — "7", "€23,876". Never a raw number to be formatted here. */
+  value: string;
+  label: string;
+  /** Trend series for the sparkline. Omit to render the tile without one. */
+  series?: number[];
+  delta?: { label: string; direction: DeltaDirection };
+  /** Renders the whole tile as a link. */
+  to?: string;
+  /** Caption under the sparkline, e.g. "Last 7 days". */
+  hint?: string;
+  className?: string;
+}
+
+/**
+ * StatTile — the compact "2 ∿ +2 / Sales Quotes" card from the reference.
+ *
+ * Small number, trend shape, delta chip. Sits in a row inside a
+ * `.surface-recessed` group; it is NOT a standalone raised card.
+ */
+export const StatTile: React.FC<StatTileProps> = ({
+  value,
+  label,
+  series,
+  delta,
+  to,
+  hint,
+  className,
+}) => {
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-2">
+        <Metric value={value} size="sm" />
+        {delta && <DeltaChip label={delta.label} direction={delta.direction} className="mt-1" />}
+      </div>
+
+      {series && series.length > 1 && (
+        <div className="mt-2 flex items-end gap-2">
+          <Sparkline data={series} width={68} height={22} />
+          {hint && <span className="text-[10px] text-muted-foreground leading-none pb-0.5">{hint}</span>}
+        </div>
+      )}
+
+      <p className="mt-3 text-sm text-muted-foreground leading-tight">{label}</p>
+    </>
+  );
+
+  const shell = cn(
+    'surface-raised p-4 block transition-all duration-200',
+    to && 'hover:-translate-y-0.5 hover:border-vivid/40',
+    className,
+  );
+
+  if (to) {
+    return (
+      <Link to={to} className={shell}>
+        {body}
+      </Link>
+    );
+  }
+  return <div className={shell}>{body}</div>;
+};

--- a/src/components/core/DesignSystem/index.ts
+++ b/src/components/core/DesignSystem/index.ts
@@ -1,8 +1,12 @@
 /**
  * Design System Components
  *
- * Reusable components following the dark dashboard design
- * All components are styled to match the screenshot provided
+ * Reusable components following the dark dashboard design.
+ *
+ * The `Metric` family below is the 2026 command-center language (see
+ * `.claude/design-system.md` §16). Reach for it whenever a screen has a headline
+ * number: the platform's flatness came from having no type tier above 36px, so a
+ * KPI and a table cell carried identical visual weight.
  */
 
 export { DashboardCard } from './DashboardCard';
@@ -12,3 +16,19 @@ export { Badge } from './Badge';
 export { Button } from './Button';
 export { Input } from './Input';
 
+// ── 2026 command-center language ────────────────────────────────────────────
+export { Metric, splitMetric, type MetricSize } from './Metric';
+export { Sparkline } from './Sparkline';
+export {
+  MicroLabel,
+  DeltaChip,
+  Meter,
+  CircleAction,
+  deltaDirection,
+  type DeltaDirection,
+} from './MetricParts';
+export { StatTile } from './StatTile';
+export { KpiCard, type ComparePeriod } from './KpiCard';
+export { MeshCard } from './MeshCard';
+export { QuickActions, type QuickAction } from './QuickActions';
+export { NotchPanel, NotchGroup } from './NotchPanel';

--- a/src/components/core/ui/card.tsx
+++ b/src/components/core/ui/card.tsx
@@ -2,20 +2,34 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/** Elevation is the hierarchy the old system lacked: every surface was the same
+ *  glass panel, so a grouping container, a single-idea card and a hero all read
+ *  identically. `glass` stays the default so the 307 existing call sites are
+ *  unchanged in kind — only sharpened. */
+export type CardElevation = 'glass' | 'flat' | 'raised' | 'float';
+
+const ELEVATION_SHADOW: Record<CardElevation, string> = {
+  glass: 'var(--glass-shadow), inset 0 1px 0 rgba(255,255,255,0.045)',
+  flat: 'var(--elev-flat)',
+  raised: 'var(--elev-raise)',
+  float: 'var(--elev-float)',
+};
+
 const Card = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, style, ...props }, ref) => (
+  React.HTMLAttributes<HTMLDivElement> & { elevation?: CardElevation }
+>(({ className, style, elevation = 'glass', ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
-      'gradient-border rounded-2xl transition-all duration-300',
+      'gradient-border rounded-[1.25rem] transition-all duration-300',
       className,
     )}
     style={{
-      background: 'var(--glass-background)',
-      backdropFilter: 'blur(var(--glass-blur))',
+      background: elevation === 'glass' ? 'var(--glass-background)' : 'hsl(var(--card))',
+      backdropFilter: elevation === 'glass' ? 'blur(var(--glass-blur))' : undefined,
       border: '1px solid transparent',
+      boxShadow: ELEVATION_SHADOW[elevation],
       ...style,
     }}
     {...props}

--- a/src/components/features/dashboard/Dashboard.tsx
+++ b/src/components/features/dashboard/Dashboard.tsx
@@ -9,17 +9,17 @@ export const Dashboard: React.FC = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="p-3 sm:p-6 max-w-[1600px] mx-auto space-y-4 sm:space-y-6">
+    <div className="p-3 sm:p-6 lg:p-8 max-w-[1600px] mx-auto space-y-8 sm:space-y-10">
+      {/* Command center first: greeting, quick actions, headline metrics, the one
+          mesh surface, then the Activities panel. Numbers lead the page — the old
+          order opened on a 400px search hero, so the state of the business was
+          below the fold on every laptop. */}
       <div className="grid grid-cols-12 gap-6 items-stretch">
-        {/* Search-first work surface */}
-        <div className="col-span-12 lg:col-span-8 overflow-hidden">
-          <HeroSection onNavigate={navigate} />
-        </div>
-
-        {/* My Office — greeting + personal numbers (finance/projects/tasks/inbox)
-            + KAI live insights, all in one command panel (per-workspace, cached). */}
         <MyOffice />
       </div>
+
+      {/* Search-first work surface */}
+      <HeroSection onNavigate={navigate} />
 
       {/* Latest content across the platform (generated areas) */}
       <LatestWidgets />

--- a/src/components/features/dashboard/MyOffice.tsx
+++ b/src/components/features/dashboard/MyOffice.tsx
@@ -1,28 +1,30 @@
-import React, { useEffect, useState } from 'react';
-import { formatMoney } from '@/utils/decimal';
-import { Link } from 'react-router-dom';
+import React from 'react';
 import {
   Wallet,
   FolderKanban,
   ListChecks,
-  Inbox as InboxIcon,
-  Sparkles,
   AlertTriangle,
   TrendingUp,
   Lightbulb,
   Info,
   RefreshCw,
-  ArrowRight,
 } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+
+import { formatMoney } from '@/utils/decimal';
 import { useWorkspace } from '@/contexts/WorkspaceContext';
-import { useAuth } from '@/contexts/AuthContext';
-import { inboxApi } from '@/services/inboxApi';
+import type { InsightTone } from '@/services/dashboardInsightsService';
 import {
-  getDashboardInsights,
-  type DashboardInsights,
-  type InsightTone,
-} from '@/services/dashboardInsightsService';
+  MicroLabel,
+  KpiCard,
+  MeshCard,
+  StatTile,
+  NotchPanel,
+  NotchGroup,
+  QuickActions,
+  type QuickAction,
+} from '@/components/core/DesignSystem';
+
+import { useOfficeIdentity, useOfficeStats, useOfficeInsights } from './useOfficeData';
 
 // ── helpers ─────────────────────────────────────────────────────────────────
 function money(n: number, currency = 'EUR'): string {
@@ -30,373 +32,221 @@ function money(n: number, currency = 'EUR'): string {
 }
 
 const TONE_STYLES: Record<InsightTone, { icon: React.ComponentType<{ className?: string }>; cls: string; chip: string }> = {
-  warning: { icon: AlertTriangle, cls: 'text-amber-400', chip: 'bg-amber-400/12' },
-  positive: { icon: TrendingUp, cls: 'text-emerald-400', chip: 'bg-emerald-400/12' },
+  warning: { icon: AlertTriangle, cls: 'text-amber', chip: 'bg-amber/12' },
+  positive: { icon: TrendingUp, cls: 'text-vivid', chip: 'bg-vivid/12' },
   tip: { icon: Lightbulb, cls: 'text-primary', chip: 'bg-primary/12' },
   info: { icon: Info, cls: 'text-muted-foreground', chip: 'bg-muted' },
 };
 
-// ── stat tile ─────────────────────────────────────────────────────────────────
-interface StatState {
-  finance: { total: number; count: number; overdue: number; currency: string };
-  projects: number;
-  tasks: number;
-  inbox: number;
-}
+/** The five things a session actually starts with.
+ *
+ *  These point at the LIST pages, not `/…/new`: the platform has no bare `/new`
+ *  routes at all — creation happens through each list's own create control (and
+ *  for money documents, deliberately so; a prefill has to pass through numbering
+ *  and buyer-risk rather than being conjured from a shortcut). Note `/moodboard`
+ *  is singular — the plural is not a route. */
+const QUICK_ACTIONS: QuickAction[] = [
+  { label: 'Quotes', to: '/quotes' },
+  { label: 'Invoices', to: '/finance' },
+  { label: 'Projects', to: '/projects' },
+  { label: 'MoodBoards', to: '/moodboard' },
+  { label: 'Contacts', to: '/crm' },
+];
 
-const EMPTY_STATS: StatState = {
-  finance: { total: 0, count: 0, overdue: 0, currency: 'EUR' },
-  projects: 0,
-  tasks: 0,
-  inbox: 0,
-};
-
-function StatTile({
-  icon: Icon,
-  to,
-  value,
-  label,
-  accent,
-  loading,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  to: string;
-  value: React.ReactNode;
-  label: string;
-  accent?: boolean;
-  loading: boolean;
-}) {
-  return (
-    <Link
-      to={to}
-      className="group flex flex-col gap-1 rounded-xl border border-white/8 bg-background/50 p-3 transition-colors hover:border-primary/40 hover:bg-background/80"
-    >
-      <div className="flex items-center justify-between">
-        <Icon className={`h-4 w-4 ${accent ? 'text-amber-400' : 'text-primary'}`} />
-        <ArrowRight className="h-3 w-3 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
-      </div>
-      {loading ? (
-        /* h-5, no margin: exactly the box the resolved value occupies (text-xl +
-           leading-none = 20px, and the <p> below has no margin of its own). The old
-           h-6 + mt-0.5 was 6px taller, so all four tiles shrank a little the moment
-           the numbers landed. */
-        <div className="h-5 w-2/3 rounded bg-primary/10 animate-pulse" />
-      ) : (
-        <p className="text-xl font-display leading-none tracking-tight tabular-nums" style={{ fontWeight: 700 }}>
-          {value}
-        </p>
-      )}
-      {/* Two lines, always. The label is derived from the STATS, not skeletoned with
-          them: it reads "All settled" / "0 open tasks" while the queries are in flight
-          and "outstanding · 12 invoices" after — which wraps to a second line on any
-          column narrower than ~1400px, growing all four tiles the moment the numbers
-          land. Reserving both lines costs one blank line on wide screens and
-          removes the shift everywhere. */}
-      <p className="text-[11px] text-muted-foreground leading-snug min-h-[1.9rem] line-clamp-2">{label}</p>
-    </Link>
-  );
-}
+/** Skeleton shaped like the metric it stands in for, so nothing reflows on load. */
+const MetricSkeleton: React.FC<{ className?: string }> = ({ className }) => (
+  <div className={`h-[3.5rem] w-3/4 rounded-lg bg-foreground/8 animate-pulse ${className ?? ''}`} />
+);
 
 // ── main panel ──────────────────────────────────────────────────────────────
 const MyOfficeImpl: React.FC = () => {
   const { activeWorkspaceId, loading: workspaceLoading } = useWorkspace();
-  const { user } = useAuth();
-  const [personName, setPersonName] = useState('');
-  const [companyName, setCompanyName] = useState('');
-  const [stats, setStats] = useState<StatState>(EMPTY_STATS);
-  const [statsLoading, setStatsLoading] = useState(true);
-
-  const [insights, setInsights] = useState<DashboardInsights | null>(null);
-  const [insightsLoading, setInsightsLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-
-  // ── greeting names ── two independent values:
-  //   personName  → the human (full_name → signup display_name → email local-part)
-  //   companyName → the business, resolved from the first source that has one:
-  //                 the profile's linked company (crm_companies) → the workspace
-  //                 finance issuer (finance_settings.business_name) → branding.
-  // The workspace label ("Default Workspace") is a system name and never used.
-  useEffect(() => {
-    // Wait for the workspace to settle. The panel now mounts DURING that resolution
-    // (see Index), and `activeWorkspaceId` is in the dep list, so running early just
-    // buys a throwaway round of the same three queries with no workspace to read the
-    // issuer name from.
-    if (!user || workspaceLoading) return;
-    let alive = true;
-    (async () => {
-      const metaName = (user.user_metadata?.display_name as string | undefined)?.trim() || '';
-      const emailPrefix = user.email?.split('@')[0]?.trim() || '';
-
-      const { data: prof } = await supabase
-        .from('user_profiles')
-        .select('full_name, business_id, branding_company_name')
-        .eq('user_id', user.id)
-        .maybeSingle();
-      const fullName = (prof?.full_name as string | null)?.trim() || '';
-      const person = [fullName, metaName, emailPrefix].find(Boolean) || '';
-
-      let linkedCompany = '';
-      if (prof?.business_id) {
-        const { data: company } = await supabase
-          .from('crm_companies')
-          .select('name')
-          .eq('id', prof.business_id)
-          .maybeSingle();
-        linkedCompany = (company?.name as string | null)?.trim() || '';
-      }
-
-      let issuerName = '';
-      if (activeWorkspaceId) {
-        const { data: fs } = await supabase
-          .from('finance_settings')
-          .select('business_name')
-          .eq('workspace_id', activeWorkspaceId)
-          .maybeSingle();
-        issuerName = (fs?.business_name as string | null)?.trim() || '';
-      }
-
-      const branding = (prof?.branding_company_name as string | null)?.trim() || '';
-      const company = [linkedCompany, issuerName, branding].find(Boolean) || '';
-
-      if (alive) {
-        setPersonName(person);
-        setCompanyName(company);
-      }
-    })().catch(() => {});
-    return () => {
-      alive = false;
-    };
-  }, [user, activeWorkspaceId, workspaceLoading]);
-
-  // ── stats ──
-  useEffect(() => {
-    if (!activeWorkspaceId) {
-      // Only leave the loading state once we KNOW there is no workspace. While the
-      // workspace is still resolving, dropping out of it renders "—" / "0" in the
-      // tiles for a beat and then swaps in the real numbers.
-      if (!workspaceLoading) setStatsLoading(false);
-      return;
-    }
-    let alive = true;
-    setStatsLoading(true);
-    (async () => {
-      const { data: userData } = await supabase.auth.getUser();
-      const userId = userData.user?.id ?? null;
-
-      const [invRes, projRes, taskRes, threadsRes] = await Promise.all([
-        supabase
-          .from('invoices')
-          .select('amount_due, due_at, status, currency')
-          .eq('workspace_id', activeWorkspaceId)
-          .in('status', ['issued', 'partially_paid', 'overdue'])
-          .limit(1000),
-        supabase
-          .from('projects')
-          .select('id', { count: 'exact', head: true })
-          .eq('workspace_id', activeWorkspaceId)
-          .in('status', ['planning', 'in_progress', 'on_hold']),
-        userId
-          ? supabase
-              .from('project_tasks')
-              .select('id', { count: 'exact', head: true })
-              .eq('assignee_id', userId)
-              .in('status', ['todo', 'in_progress', 'blocked'])
-          : Promise.resolve({ count: 0 } as { count: number | null }),
-        inboxApi.listThreads({ status: 'open' }).catch(() => ({ threads: [] as unknown[] })),
-      ]);
-
-      if (!alive) return;
-
-      const invRows = (invRes.data ?? []) as Array<{ amount_due: number | null; due_at: string | null; status: string; currency: string }>;
-      const now = Date.now();
-      let total = 0;
-      let overdue = 0;
-      let currency = 'EUR';
-      for (const r of invRows) {
-        total += Number(r.amount_due ?? 0);
-        if (r.status === 'overdue' || (r.due_at && new Date(r.due_at).getTime() < now)) overdue++;
-        if (r.currency) currency = r.currency;
-      }
-
-      setStats({
-        finance: { total: Math.round(total), count: invRows.length, overdue, currency },
-        projects: projRes.count ?? 0,
-        tasks: (taskRes as { count: number | null }).count ?? 0,
-        inbox: ((threadsRes as { threads?: unknown[] })?.threads ?? []).length,
-      });
-      setStatsLoading(false);
-    })().catch(() => alive && setStatsLoading(false));
-    return () => {
-      alive = false;
-    };
-  }, [activeWorkspaceId, workspaceLoading]);
-
-  // ── insights ──
-  const loadInsights = async (force = false) => {
-    if (!activeWorkspaceId) {
-      // Same as the stats above — hold the skeleton until the workspace is settled,
-      // otherwise the "Pro tip" empty state flashes in before the real insights.
-      if (!workspaceLoading) setInsightsLoading(false);
-      return;
-    }
-    if (force) setRefreshing(true);
-    else setInsightsLoading(true);
-    try {
-      const res = await getDashboardInsights(activeWorkspaceId, { force });
-      setInsights(res.insights);
-    } catch {
-      setInsights(null);
-    } finally {
-      setInsightsLoading(false);
-      setRefreshing(false);
-    }
-  };
-
-  useEffect(() => {
-    void loadInsights(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeWorkspaceId, workspaceLoading]);
+  const { personName, companyName } = useOfficeIdentity();
+  const { stats, loading: statsLoading } = useOfficeStats();
+  const { insights, loading: insightsLoading, refreshing, reload } = useOfficeInsights();
 
   // A user with genuinely no workspace has no office to show — but `activeWorkspaceId`
-  // is ALSO null for the first beat of every load, while the workspace resolves.
-  // Returning null there rendered the dashboard's top row hero-only and then grew it
-  // by this panel's height a moment later, shoving the widgets below down the page:
-  // the "grid starts smaller and then expands" blink. Render the panel through the
-  // resolving phase — its stat/insight skeletons above already hold the full height —
-  // and only drop out once we actually know there is no workspace.
+  // is ALSO null for the first beat of every load. Rendering null there and then
+  // growing the page a moment later is the "grid starts smaller and expands" blink,
+  // so render through the resolving phase and only drop out once we KNOW.
   if (!activeWorkspaceId && !workspaceLoading) return null;
 
+  const fin = stats.finance;
+  const headline = insights?.insights?.[0] ?? null;
+
   return (
-    <div
-      className="col-span-12 lg:col-span-4 rounded-2xl border border-primary/15 bg-card p-5 flex flex-col gap-4 relative overflow-hidden"
-      style={{ backgroundImage: 'radial-gradient(420px 200px at 90% -20%, hsl(var(--primary) / 0.10), transparent 70%)' }}
-    >
-      {/* Greeting */}
-      <div>
-        <p className="text-[11px] uppercase tracking-[0.14em] text-primary truncate">
-          {companyName ? `My office, ${companyName}` : 'My office'}
-        </p>
-        <h2 className="font-display text-lg tracking-tight mt-0.5 truncate" style={{ fontWeight: 600 }}>
-          {personName ? `Welcome back, ${personName}` : 'Welcome back'}
-        </h2>
+    <div className="col-span-12 space-y-6">
+      {/* ── Greeting + quick actions ───────────────────────────────────── */}
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0">
+          <MicroLabel className="mb-2">
+            {companyName ? `My Office · ${companyName}` : 'My Office'}
+          </MicroLabel>
+          <h2 className="display-hero text-foreground truncate">
+            {personName ? `Welcome back, ${personName}` : 'Welcome back'}
+          </h2>
+        </div>
+        <QuickActions actions={QUICK_ACTIONS} moreTo="/agent-hub" className="shrink-0" />
       </div>
 
-      {/* Personal stats */}
-      <div className="grid grid-cols-2 gap-2.5">
-        <StatTile
-          icon={Wallet}
-          to="/finance"
-          loading={statsLoading}
-          value={stats.finance.count === 0 ? '—' : money(stats.finance.total, stats.finance.currency)}
-          label={
-            stats.finance.count === 0
-              ? 'All settled'
-              : `outstanding · ${stats.finance.count} invoice${stats.finance.count !== 1 ? 's' : ''}`
-          }
-          accent={stats.finance.overdue > 0}
-        />
-        <StatTile
-          icon={FolderKanban}
-          to="/projects"
-          loading={statsLoading}
-          value={stats.projects}
-          label={`active project${stats.projects !== 1 ? 's' : ''}`}
-        />
-        <StatTile
-          icon={ListChecks}
-          to="/projects"
-          loading={statsLoading}
-          value={stats.tasks}
-          label={`open task${stats.tasks !== 1 ? 's' : ''}`}
-        />
-        <StatTile
-          icon={InboxIcon}
-          to="/inbox"
-          loading={statsLoading}
-          value={stats.inbox}
-          label={`open conversation${stats.inbox !== 1 ? 's' : ''}`}
-        />
-      </div>
+      {/* ── Headline metrics + the one loud surface ────────────────────── */}
+      <div className="grid grid-cols-12 gap-4 sm:gap-5 items-stretch">
+        <div className="col-span-12 xl:col-span-8 grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-5">
+          {statsLoading ? (
+            <>
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="surface-raised p-5 sm:p-6">
+                  <div className="h-3 w-1/2 rounded bg-foreground/8 animate-pulse" />
+                  <MetricSkeleton className="mt-5" />
+                </div>
+              ))}
+            </>
+          ) : (
+            <>
+              <KpiCard
+                label="Outstanding"
+                icon={Wallet}
+                value={fin.count === 0 ? '—' : money(fin.total, fin.currency)}
+                size="lg"
+                to="/finance"
+                caption={
+                  fin.count === 0
+                    ? 'All settled'
+                    : `across ${fin.count} invoice${fin.count !== 1 ? 's' : ''}${fin.overdue > 0 ? ` · ${fin.overdue} overdue` : ''}`
+                }
+                {...(fin.overdue > 0
+                  ? { delta: { label: `${fin.overdue} overdue`, direction: 'down' as const } }
+                  : {})}
+              />
+              <KpiCard
+                label="Active Projects"
+                icon={FolderKanban}
+                value={String(stats.projects)}
+                size="lg"
+                to="/projects"
+                caption={stats.projects === 0 ? 'Nothing in flight' : 'planning, in progress or on hold'}
+              />
+              <KpiCard
+                label="My Open Tasks"
+                icon={ListChecks}
+                value={String(stats.tasks)}
+                size="lg"
+                to="/projects"
+                caption={stats.tasks === 0 ? 'Inbox zero' : 'assigned to you'}
+              />
+            </>
+          )}
+        </div>
 
-      {/* KAI insights */}
-      <div className="mt-1 pt-4 border-t border-white/8 flex-1 flex flex-col">
-        <div className="flex items-center justify-between mb-3">
-          <span
-            className="inline-flex items-center gap-1.5 text-[11px] text-primary bg-primary/12 border border-primary/25 rounded-full px-2.5 py-1"
-            style={{ fontWeight: 600 }}
+        {/* The single saturated surface on the page. Carries the top KAI insight;
+            the rest of the set lives in the Activities panel below. */}
+        <div className="col-span-12 xl:col-span-4">
+          <MeshCard
+            eyebrow="KAI · Live Insights"
+            to="/agent-hub"
+            {...(insights?.insights?.length
+              ? { pager: { count: Math.min(insights.insights.length, 4), active: 0 } }
+              : {})}
+            className="h-full"
           >
-            <Sparkles className="h-3 w-3" /> KAI · Live insights
-          </span>
-          {insights && (
+            {insightsLoading ? (
+              <span className="block h-6 w-3/4 rounded bg-white/25 animate-pulse" />
+            ) : headline ? (
+              headline.title
+            ) : (
+              <>
+                Ask JARVIS to compare specs across brands, or build a quote from your catalog.
+              </>
+            )}
+          </MeshCard>
+        </div>
+      </div>
+
+      {/* ── Activities ─────────────────────────────────────────────────── */}
+      <NotchPanel
+        title="Activities"
+        count={stats.projects + stats.tasks + stats.inbox}
+        toolbar={
+          insights && (
             <button
-              onClick={() => loadInsights(true)}
+              onClick={() => void reload(true)}
               disabled={refreshing}
               title="Refresh insights"
-              className="text-muted-foreground hover:text-foreground transition-colors p-1 -mr-1 disabled:opacity-50"
+              className="circle-action"
+              aria-label="Refresh insights"
             >
               <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? 'animate-spin' : ''}`} />
             </button>
-          )}
-        </div>
+          )
+        }
+      >
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto_1fr] gap-6">
+          <NotchGroup label="Ongoing Work">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              <StatTile
+                value={String(stats.projects)}
+                label="Projects"
+                to="/projects"
+                delta={
+                  stats.projects > 0 ? { label: 'active', direction: 'up' as const } : undefined
+                }
+              />
+              <StatTile value={String(stats.tasks)} label="Open Tasks" to="/projects" />
+              <StatTile value={String(stats.inbox)} label="Conversations" to="/inbox" />
+            </div>
+          </NotchGroup>
 
-        {/* FIXED height, not min-height, and it scrolls. Insights come from an LLM edge
-            function — the slowest thing on the dashboard — and the endpoint returns
-            anywhere from 2 to 5 of them with one-to-two-sentence bodies, so the resolved
-            height is genuinely unknowable at paint time: a reserve big enough for five
-            three-line insights would be mostly dead space, and anything smaller grows the
-            panel when the call lands. This panel is the tallest thing in the top grid row,
-            so its height IS the row's height — any growth here shoves LatestWidgets down
-            the page seconds into the load. The height steps with the breakpoint because
-            the COLUMN steps with it — a 3-insight set measures 263px in the 264px-wide
-            lg column and 214px in the 459px-wide one — so each step is the measured fit
-            for the typical set at that width, and anything longer scrolls. Still a
-            constant per width: nothing the endpoint returns can change it. All three
-            states (loading / pro-tip / resolved) occupy exactly this box. */}
-        <div className="h-[15.5rem] sm:h-[13.5rem] lg:h-[16.5rem] xl:h-[14.5rem] 2xl:h-[13.5rem] overflow-y-auto">
-          {insightsLoading ? (
-            /* Shaped like a real insight row (icon chip + title + two-line body), not thin
-               bars — a skeleton that doesn't match the row it stands in for is what let the
-               height gap open up in the first place. */
-            <div className="space-y-2.5 animate-pulse">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="flex gap-2.5 items-start p-1.5 -mx-1.5">
-                  <span className="w-7 h-7 rounded-lg bg-primary/10 shrink-0" />
-                  <div className="min-w-0 flex-1 space-y-1.5">
-                    <div className="h-3 bg-primary/10 rounded w-1/2" />
-                    <div className="h-2.5 bg-primary/10 rounded w-full" />
-                    <div className="h-2.5 bg-primary/10 rounded w-4/5" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : !insights ? (
-            <div className="p-3 bg-primary/5 rounded-lg border border-primary/20">
-              <span className="text-[11px] font-medium text-primary uppercase tracking-wider">Pro tip</span>
-              <p className="text-sm mt-1 leading-snug">
-                Ask JARVIS to compare technical specs across brands, or prepare a quote from your catalog.
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-2.5">
-              {insights.insights.map((ins, i) => {
-                const t = TONE_STYLES[ins.tone] ?? TONE_STYLES.info;
-                const Icon = t.icon;
-                return (
-                  <div key={i} className="flex gap-2.5 items-start p-1.5 -mx-1.5 rounded-xl hover:bg-white/5 transition-colors">
-                    <span className={`w-7 h-7 rounded-lg grid place-items-center shrink-0 ${t.chip}`}>
-                      <Icon className={`h-3.5 w-3.5 ${t.cls}`} />
-                    </span>
-                    <div className="min-w-0">
-                      <p className="text-sm leading-tight" style={{ fontWeight: 500 }}>{ins.title}</p>
-                      <p className="text-xs text-muted-foreground mt-0.5 leading-snug">{ins.body}</p>
+          <div className="hidden lg:block w-px bg-border/60" />
+
+          <NotchGroup label="Live Insights">
+            {insightsLoading ? (
+              <div className="space-y-2.5 animate-pulse">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="flex gap-2.5 items-start">
+                    <span className="w-7 h-7 rounded-lg bg-foreground/8 shrink-0" />
+                    <div className="min-w-0 flex-1 space-y-1.5">
+                      <div className="h-3 bg-foreground/8 rounded w-1/2" />
+                      <div className="h-2.5 bg-foreground/8 rounded w-4/5" />
                     </div>
                   </div>
-                );
-              })}
-            </div>
-          )}
+                ))}
+              </div>
+            ) : !insights ? (
+              <div className="surface-raised p-4">
+                <MicroLabel>Pro Tip</MicroLabel>
+                <p className="text-sm mt-2 leading-snug">
+                  Ask JARVIS to compare technical specs across brands, or prepare a quote from your
+                  catalog.
+                </p>
+              </div>
+            ) : (
+              /* Fixed height that scrolls: the endpoint returns anywhere from 2 to 5
+                 insights of one-to-two sentences, so the resolved height is genuinely
+                 unknowable at paint time. A constant box removes the reflow. */
+              <div className="h-[13rem] overflow-y-auto pr-1 space-y-2.5">
+                {insights.insights.map((ins, i) => {
+                  const t = TONE_STYLES[ins.tone] ?? TONE_STYLES.info;
+                  const Icon = t.icon;
+                  return (
+                    <div
+                      key={i}
+                      className="flex gap-2.5 items-start p-1.5 -mx-1.5 rounded-xl hover:bg-foreground/5 transition-colors"
+                    >
+                      <span className={`w-7 h-7 rounded-lg grid place-items-center shrink-0 ${t.chip}`}>
+                        <Icon className={`h-3.5 w-3.5 ${t.cls}`} />
+                      </span>
+                      <div className="min-w-0">
+                        <p className="text-sm leading-tight font-medium">{ins.title}</p>
+                        <p className="text-xs text-muted-foreground mt-0.5 leading-snug">{ins.body}</p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </NotchGroup>
         </div>
-      </div>
+      </NotchPanel>
     </div>
   );
 };

--- a/src/components/features/dashboard/useOfficeData.ts
+++ b/src/components/features/dashboard/useOfficeData.ts
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+
+import { supabase } from '@/integrations/supabase/client';
+import { useWorkspace } from '@/contexts/WorkspaceContext';
+import { useAuth } from '@/contexts/AuthContext';
+import { inboxApi } from '@/services/inboxApi';
+import { getDashboardInsights, type DashboardInsights } from '@/services/dashboardInsightsService';
+
+/* ────────────────────────────────────────────────────────────────────────────
+   Data layer for the dashboard command center.
+   Extracted verbatim from MyOffice.tsx so the presentation could be rebuilt to
+   the 2026 language without touching the queries or their loading semantics.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+export interface OfficeStats {
+  finance: { total: number; count: number; overdue: number; currency: string };
+  projects: number;
+  tasks: number;
+  inbox: number;
+}
+
+export const EMPTY_OFFICE_STATS: OfficeStats = {
+  finance: { total: 0, count: 0, overdue: 0, currency: 'EUR' },
+  projects: 0,
+  tasks: 0,
+  inbox: 0,
+};
+
+/** Greeting names — two independent values:
+ *    personName  → the human (full_name → signup display_name → email local-part)
+ *    companyName → the business, from the first source that has one:
+ *                  linked crm_company → finance_settings.business_name → branding.
+ *  The workspace label ("Default Workspace") is a system name and never used. */
+export function useOfficeIdentity() {
+  const { activeWorkspaceId, loading: workspaceLoading } = useWorkspace();
+  const { user } = useAuth();
+  const [personName, setPersonName] = useState('');
+  const [companyName, setCompanyName] = useState('');
+
+  useEffect(() => {
+    // Wait for the workspace to settle. The panel mounts DURING that resolution and
+    // `activeWorkspaceId` is in the dep list, so running early just buys a throwaway
+    // round of the same three queries with no workspace to read the issuer from.
+    if (!user || workspaceLoading) return;
+    let alive = true;
+    (async () => {
+      const metaName = (user.user_metadata?.display_name as string | undefined)?.trim() || '';
+      const emailPrefix = user.email?.split('@')[0]?.trim() || '';
+
+      const { data: prof } = await supabase
+        .from('user_profiles')
+        .select('full_name, business_id, branding_company_name')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      const fullName = (prof?.full_name as string | null)?.trim() || '';
+      const person = [fullName, metaName, emailPrefix].find(Boolean) || '';
+
+      let linkedCompany = '';
+      if (prof?.business_id) {
+        const { data: company } = await supabase
+          .from('crm_companies')
+          .select('name')
+          .eq('id', prof.business_id)
+          .maybeSingle();
+        linkedCompany = (company?.name as string | null)?.trim() || '';
+      }
+
+      let issuerName = '';
+      if (activeWorkspaceId) {
+        const { data: fs } = await supabase
+          .from('finance_settings')
+          .select('business_name')
+          .eq('workspace_id', activeWorkspaceId)
+          .maybeSingle();
+        issuerName = (fs?.business_name as string | null)?.trim() || '';
+      }
+
+      const branding = (prof?.branding_company_name as string | null)?.trim() || '';
+      const company = [linkedCompany, issuerName, branding].find(Boolean) || '';
+
+      if (alive) {
+        setPersonName(person);
+        setCompanyName(company);
+      }
+    })().catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [user, activeWorkspaceId, workspaceLoading]);
+
+  return { personName, companyName };
+}
+
+export function useOfficeStats() {
+  const { activeWorkspaceId, loading: workspaceLoading } = useWorkspace();
+  const [stats, setStats] = useState<OfficeStats>(EMPTY_OFFICE_STATS);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!activeWorkspaceId) {
+      // Only leave the loading state once we KNOW there is no workspace. While the
+      // workspace is still resolving, dropping out of it renders "—" / "0" in the
+      // tiles for a beat and then swaps in the real numbers.
+      if (!workspaceLoading) setLoading(false);
+      return;
+    }
+    let alive = true;
+    setLoading(true);
+    (async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData.user?.id ?? null;
+
+      const [invRes, projRes, taskRes, threadsRes] = await Promise.all([
+        supabase
+          .from('invoices')
+          .select('amount_due, due_at, status, currency')
+          .eq('workspace_id', activeWorkspaceId)
+          .in('status', ['issued', 'partially_paid', 'overdue'])
+          .limit(1000),
+        supabase
+          .from('projects')
+          .select('id', { count: 'exact', head: true })
+          .eq('workspace_id', activeWorkspaceId)
+          .in('status', ['planning', 'in_progress', 'on_hold']),
+        userId
+          ? supabase
+              .from('project_tasks')
+              .select('id', { count: 'exact', head: true })
+              .eq('assignee_id', userId)
+              .in('status', ['todo', 'in_progress', 'blocked'])
+          : Promise.resolve({ count: 0 } as { count: number | null }),
+        inboxApi.listThreads({ status: 'open' }).catch(() => ({ threads: [] as unknown[] })),
+      ]);
+
+      if (!alive) return;
+
+      const invRows = (invRes.data ?? []) as Array<{
+        amount_due: number | null;
+        due_at: string | null;
+        status: string;
+        currency: string;
+      }>;
+      const now = Date.now();
+      let total = 0;
+      let overdue = 0;
+      let currency = 'EUR';
+      for (const r of invRows) {
+        total += Number(r.amount_due ?? 0);
+        if (r.status === 'overdue' || (r.due_at && new Date(r.due_at).getTime() < now)) overdue++;
+        if (r.currency) currency = r.currency;
+      }
+
+      setStats({
+        finance: { total: Math.round(total), count: invRows.length, overdue, currency },
+        projects: projRes.count ?? 0,
+        tasks: (taskRes as { count: number | null }).count ?? 0,
+        inbox: ((threadsRes as { threads?: unknown[] })?.threads ?? []).length,
+      });
+      setLoading(false);
+    })().catch(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [activeWorkspaceId, workspaceLoading]);
+
+  return { stats, loading };
+}
+
+export function useOfficeInsights() {
+  const { activeWorkspaceId, loading: workspaceLoading } = useWorkspace();
+  const [insights, setInsights] = useState<DashboardInsights | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = async (force = false) => {
+    if (!activeWorkspaceId) {
+      // Same as the stats above — hold the skeleton until the workspace is settled,
+      // otherwise the "Pro tip" empty state flashes in before the real insights.
+      if (!workspaceLoading) setLoading(false);
+      return;
+    }
+    if (force) setRefreshing(true);
+    else setLoading(true);
+    try {
+      const res = await getDashboardInsights(activeWorkspaceId, { force });
+      setInsights(res.insights);
+    } catch {
+      setInsights(null);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    void load(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeWorkspaceId, workspaceLoading]);
+
+  return { insights, loading, refreshing, reload: load };
+}

--- a/src/components/shared/PageHeader.tsx
+++ b/src/components/shared/PageHeader.tsx
@@ -8,25 +8,30 @@ interface PageHeaderProps {
   actions?: React.ReactNode;
   /** Extra content rendered below the title row (e.g. search/filter bar) */
   children?: React.ReactNode;
+  /** Eyebrow above the title — the workspace / section this page belongs to. */
+  eyebrow?: string;
 }
 
-export function PageHeader({ icon: Icon, title, subtitle, actions, children }: PageHeaderProps) {
+export function PageHeader({ icon: Icon, title, subtitle, actions, children, eyebrow }: PageHeaderProps) {
   return (
-    <section className="px-4 sm:px-6 py-3 sm:py-4 border-b border-white/8">
+    <section className="px-4 sm:px-6 pt-5 pb-4 sm:pt-7 sm:pb-5 border-b border-border/50">
       {/* On mobile the actions drop to their own row (and may wrap) so a wide
           primary button is never clipped off the right edge; from sm up it sits
           inline on the right. The title truncates rather than pushing actions
           off-screen. */}
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-        {/* Left: page icon + title */}
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="w-9 h-9 rounded-lg bg-primary/15 flex items-center justify-center shrink-0">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between sm:gap-4">
+        {/* Left: page icon + title. The title moved from text-lg (18px) to the
+            display tier (32px): a page title that sat 2px above body text was a
+            large part of why every screen read as flat. */}
+        <div className="flex items-start gap-3 min-w-0">
+          <div className="w-10 h-10 rounded-xl bg-primary/12 flex items-center justify-center shrink-0 mt-0.5">
             <Icon className="h-5 w-5 text-primary" />
           </div>
           <div className="min-w-0">
-            <h1 className="text-lg font-light text-foreground tracking-tight truncate">{title}</h1>
+            {eyebrow && <p className="micro-label mb-1.5">{eyebrow}</p>}
+            <h1 className="display-page text-foreground truncate">{title}</h1>
             {subtitle && (
-              <p className="text-xs text-muted-foreground mt-0.5 hidden sm:block">{subtitle}</p>
+              <p className="text-sm text-muted-foreground mt-1.5 hidden sm:block">{subtitle}</p>
             )}
           </div>
         </div>
@@ -36,11 +41,11 @@ export function PageHeader({ icon: Icon, title, subtitle, actions, children }: P
             quote with submit / share / email / download) never overflow at narrow
             and mid widths; on wide screens they stay on one line and align right. */}
         {actions && (
-          <div className="flex items-center gap-2 flex-wrap sm:justify-end">{actions}</div>
+          <div className="flex items-center gap-2 flex-wrap sm:justify-end shrink-0">{actions}</div>
         )}
       </div>
 
-      {children && <div className="mt-3">{children}</div>}
+      {children && <div className="mt-4">{children}</div>}
     </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -168,10 +168,29 @@ All colors MUST be HSL.
     --text-5xl: 3rem;      /* 48px */
     --text-6xl: 3.75rem;   /* 60px */
     --text-7xl: 4.5rem;    /* 72px */
+    --text-8xl: 6rem;      /* 96px */
+    --text-9xl: 8rem;      /* 128px */
+
+    /* ===== DISPLAY / METRIC TIER (2026 command-center redesign) =====
+       The platform had NO type tier above 36px, which is the single biggest
+       reason every screen read as flat: page titles (18px), card titles (16px)
+       and body (14px) all sat within one 4px band. These drive the oversized
+       two-tone numerals and hero headlines. */
+    --metric-sm:  1.75rem;  /* 28px — inline KPI inside a dense row */
+    --metric-md:  2.75rem;  /* 44px — standard stat tile */
+    --metric-lg:  4rem;     /* 64px — hero KPI */
+    --metric-xl:  5.5rem;   /* 88px — single-focus number */
+    --display-sm: 2rem;     /* 32px — page title */
+    --display-md: 2.75rem;  /* 44px — section hero */
+    --display-lg: 3.75rem;  /* 60px — page hero headline */
 
     /* ===== FONT FAMILY ===== */
     --font-sans: 'Averta', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     --font-display: 'Aleo', Georgia, 'Times New Roman', serif;
+    /* Numerals and display metrics use the grotesque (Averta), never the slab —
+       a slab serif at 88px reads editorial, not instrumental. Averta ships
+       100-900 self-hosted, so the weight contrast costs no extra network. */
+    --font-metric: 'Averta', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
     /* ===== FONT WEIGHTS (Open Sans - Complete Range) ===== */
     --font-light: 300;     /* Light */
@@ -183,41 +202,43 @@ All colors MUST be HSL.
 
     /* ===== DARK THEME COLOR SYSTEM ===== */
     /* Main Background - Near black */
-    --background: 258 22% 5%;   /* #0a090e — deep plum-black command center */
-    --foreground: 280 15% 93%;  /* warm near-white ink */
+    --background: 80 7% 4%;     /* #0a0b09 — near-black with a faint olive cast */
+    --foreground: 75 8% 94%;    /* cool near-white ink */
 
     /* Page container */
-    --page-background: 258 22% 5%;
+    --page-background: 80 7% 4%;
 
     /* Content sections/cards — elevation ladder step 1 */
-    --card: 266 22% 8%;         /* #141019 */
-    --card-foreground: 280 15% 93%;
+    --card: 80 6% 7%;           /* #121310 */
+    --card-foreground: 75 8% 94%;
 
-    --popover: 262 24% 12%;     /* #1b1626 — elevated */
-    --popover-foreground: 280 15% 93%;
+    --popover: 80 6% 11%;       /* #1c1e19 — elevated */
+    --popover-foreground: 75 8% 94%;
 
-    /* Primary — brightened magenta-plum (flat brand accent) */
-    --primary: 335 74% 60%;     /* #e64c8c */
-    --primary-foreground: 0 0% 100%;
+    /* Primary — ACID LIME. On the near-black page this clears ~15:1 as text AND
+       works as a fill, so the 1024 existing `text-primary` call sites stay
+       legible. Its foreground flips to near-black ink (never white). */
+    --primary: 74 89% 55%;      /* #c2f231 */
+    --primary-foreground: 80 45% 6%;  /* near-black ink ON lime fills */
 
     /* Brand gradient (plum) — reserved for IDENTITY surfaces only (PageHeader,
        logo, hero). No longer painted on every bg-primary fill; buttons, active
        tabs and nav now use the flat --primary accent. */
-    --brand-blue: 300 45% 30%;
-    --brand-red: 335 74% 60%;
-    --brand-gradient: linear-gradient(135deg, #3a1230 0%, #7a2456 46%, #c93d84 100%);
+    --brand-blue: 160 60% 26%;
+    --brand-red: 74 89% 55%;
+    --brand-gradient: linear-gradient(135deg, #10331c 0%, #3f7a24 46%, #c2f231 100%);
 
     /* Secondary — elevation ladder step 3 (recessed) */
-    --secondary: 262 24% 15%;  /* #241d31 */
+    --secondary: 80 6% 13%;  /* #212319 */
     --secondary-foreground: 0 0% 85%;
 
     /* Muted */
-    --muted: 262 24% 15%;
-    --muted-foreground: 258 14% 60%;  /* violet-grey */
+    --muted: 80 6% 13%;
+    --muted-foreground: 75 7% 60%;  /* neutral grey-olive */
 
-    /* Accent — subtle plum-tinted hover surface */
-    --accent: 280 22% 16%;
-    --accent-foreground: 300 40% 88%;
+    /* Accent — subtle olive-tinted hover surface */
+    --accent: 78 10% 15%;
+    --accent-foreground: 74 40% 88%;
 
     /* Amber - Vibrant warm highlight */
     --amber: 32 100% 65%;       /* Slightly toned amber */
@@ -229,18 +250,20 @@ All colors MUST be HSL.
     --destructive-foreground: 0 0% 100%;  /* White text */
 
     /* Borders - Subtle white borders */
-    --border: 260 16% 18%;
-    --input: 260 16% 18%;
-    --ring: 335 74% 60%;  /* Focus ring — magenta accent */
+    --border: 80 7% 15%;
+    --input: 80 7% 15%;
+    --ring: 74 89% 55%;  /* Focus ring — acid lime */
 
-    --radius: 0.5rem;  /* 8px */
+    /* 8px -> 16px. Tailwind derives rounded-md/-sm from this, so the whole app
+       moves to the softer 2026 geometry in one token. Pills stay --radius-full. */
+    --radius: 1rem;  /* 16px */
 
     /* Sidebar/TopNav - Dark theme */
-    --sidebar-background: 264 22% 7%;  /* rail — slightly lifted from bg */
-    --sidebar-foreground: 258 12% 60%;
-    --sidebar-accent: 335 74% 60%;  /* magenta active */
-    --sidebar-accent-foreground: 0 0% 100%;
-    --sidebar-border: 260 16% 18%;
+    --sidebar-background: 80 7% 6%;  /* rail — slightly lifted from bg */
+    --sidebar-foreground: 75 7% 60%;
+    --sidebar-accent: 74 89% 55%;  /* lime active */
+    --sidebar-accent-foreground: 80 45% 6%;
+    --sidebar-border: 80 7% 15%;
 
     /* Hero section background */
     --hero-background: 0 0% 11%;  /* Same as card */
@@ -290,12 +313,13 @@ All colors MUST be HSL.
     --info-foreground: 0 0% 100%;
     --info-bg: 210 60% 12%;  /* Dark blue bg */
 
-    /* Chart colors - Vibrant on dark */
-    --chart-1: 142 60% 50%;    /* Green */
-    --chart-2: 210 80% 55%;    /* Blue */
-    --chart-3: 271 70% 60%;    /* Purple */
-    --chart-4: 32 100% 65%;    /* Amber */
-    --chart-5: 349 80% 58%;    /* Red */
+    /* Chart colors — lime leads, then graphite/teal supports. Both reference
+       dashboards run ONE vivid hue against neutrals rather than a rainbow. */
+    --chart-1: 74 89% 55%;     /* Acid lime — the series that matters */
+    --chart-2: 75 6% 72%;      /* Light graphite */
+    --chart-3: 165 55% 45%;    /* Teal */
+    --chart-4: 32 95% 60%;     /* Amber — exceptions only */
+    --chart-5: 350 75% 58%;    /* Rose — negative only */
 
     /* Badge color system - Dark theme */
     --badge-pending-bg: 45 60% 12%;
@@ -323,13 +347,49 @@ All colors MUST be HSL.
     --badge-draft-border: 0 0% 25%;
 
     /* ===== GLASSMORPHISM SYSTEM (Dark) ===== */
-    --glass-background: rgba(255, 255, 255, 0.05);
+    --glass-background: rgba(255, 255, 255, 0.045);
     --glass-blur: 12px;
     --glass-border: rgba(255, 255, 255, 0.08);
     --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
 
     /* ===== REFINED SHADOWS (Dark) ===== */
     --shadow-premium: 0 10px 40px -10px rgba(0, 0, 0, 0.4), 0 5px 20px -5px rgba(0, 0, 0, 0.3);
+
+    /* ========================================
+       2026 REDESIGN TOKENS (shared shape, per-theme colour)
+       ======================================== */
+
+    /* --- VIVID: the acid data accent -------------------------------------
+       `--primary` has to stay legible as TEXT in both themes (1024 call sites),
+       which caps how acid it can go in light mode. `--vivid` is the uncapped
+       fill accent: identical in both themes, ALWAYS on near-black ink, and
+       reserved for data ornament — meters, sparklines, positive deltas, the
+       active pill, the one primary CTA on a screen. Never body text. */
+    --vivid: 74 89% 55%;              /* #c2f231 */
+    --vivid-foreground: 80 45% 6%;    /* near-black ink on vivid fills */
+    --vivid-soft: 74 89% 55% / 0.14;  /* tint wash for chips + tracks */
+
+    /* --- Elevation ladder: recessed -> flush -> raised -> floating --------
+       Replaces "every surface is the same glass panel". A recessed panel groups
+       tiles; a raised card holds one idea; floating is for the hero. */
+    --elev-recess: inset 0 1px 2px rgba(0,0,0,0.4);
+    --elev-flat:   0 1px 2px rgba(0,0,0,0.25);
+    --elev-raise:  0 4px 16px -4px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.05);
+    --elev-float:  0 24px 60px -18px rgba(0,0,0,0.65), inset 0 1px 0 rgba(255,255,255,0.07);
+    --surface-recess: rgba(255,255,255,0.028);
+
+    /* --- Mesh gradient: the ONE loud surface per screen -------------------
+       Both references keep exactly one saturated blurred-mesh panel and let
+       everything else stay quiet. Four blobs composited as radial gradients. */
+    --mesh-1: 74 89% 55%;    /* lime */
+    --mesh-2: 165 70% 45%;   /* teal */
+    --mesh-3: 258 70% 60%;   /* violet */
+    --mesh-4: 28 90% 58%;    /* amber */
+    --mesh-ink: 0 0% 100%;
+
+    /* --- Hatch: the "last period" comparison bar fill --------------------- */
+    --hatch-color: rgba(255,255,255,0.16);
+    --hatch-bg: rgba(255,255,255,0.035);
   }
 
 .dark {
@@ -361,9 +421,12 @@ All colors MUST be HSL.
     --popover: 48 30% 98%;
     --popover-foreground: 46 14% 21%;
 
-    /* Primary — muted khaki-olive (quiet-luxury); darkened to 37% L so white text
-       clears WCAG AA (≥4.5:1) in fills and the assistant chat bubble. */
-    --primary: 56 24% 37%;           /* #6b6842 — white text ~4.9:1 */
+    /* Primary — DEEP LIME. Same hue family as the dark theme's acid accent but
+       dropped to 24% L: acid lime as text on cream is ~1.4:1 and unreadable, and
+       `text-primary` has 1024 call sites. At 24% it clears AA as text on the oat
+       page (~8:1) AND takes white text as a fill. The acid pop in light mode
+       comes from `--vivid` on small deliberate fills, exactly as ClientIQ does. */
+    --primary: 74 72% 22%;           /* #47610f */
     --primary-foreground: 0 0% 100%;
 
     /* Secondary — warm sand, deeper than cards (active-nav pill tone) */
@@ -387,18 +450,18 @@ All colors MUST be HSL.
     --destructive: 12 51% 50%;
     --destructive-foreground: 0 0% 100%;
 
-    /* Olive brand gradient for identity surfaces (light) */
-    --brand-gradient: linear-gradient(135deg, #4a4726 0%, #65623c 46%, #8f8c5a 100%);
+    /* Lime brand gradient for identity surfaces (light) */
+    --brand-gradient: linear-gradient(135deg, #2c4008 0%, #4f7a15 46%, #9fd42a 100%);
 
     /* Borders / inputs — warm olive-grey lines */
     --border: 46 18% 82%;
     --input: 46 18% 83%;
-    --ring: 56 24% 37%;
+    --ring: 74 72% 22%;
 
     /* Sidebar / TopNav — ivory bar, olive active */
     --sidebar-background: 48 30% 97%;
     --sidebar-foreground: 48 12% 40%;
-    --sidebar-accent: 56 24% 37%;
+    --sidebar-accent: 74 72% 22%;
     --sidebar-accent-foreground: 0 0% 100%;
     --sidebar-border: 46 18% 82%;
 
@@ -446,12 +509,12 @@ All colors MUST be HSL.
     --info-foreground: 0 0% 100%;
     --info-bg: 210 85% 94%;
 
-    /* Chart colors — slightly deepened for contrast on light */
-    --chart-1: 142 60% 40%;
-    --chart-2: 210 80% 48%;
-    --chart-3: 271 60% 52%;
-    --chart-4: 32 90% 48%;
-    --chart-5: 349 72% 52%;
+    /* Chart colors — lime leads, graphite/teal support (deepened for light) */
+    --chart-1: 74 72% 30%;
+    --chart-2: 48 8% 45%;
+    --chart-3: 165 60% 32%;
+    --chart-4: 32 90% 42%;
+    --chart-5: 349 72% 48%;
 
     /* Badge color system — pale tint bg, deep text */
     --badge-pending-bg: 45 90% 90%;
@@ -488,6 +551,28 @@ All colors MUST be HSL.
 
     /* ===== REFINED SHADOWS (Light) ===== */
     --shadow-premium: 0 10px 40px -10px rgba(0, 0, 0, 0.14), 0 5px 20px -5px rgba(0, 0, 0, 0.08);
+
+    /* ===== 2026 REDESIGN TOKENS (light) ===== */
+    /* Vivid is deliberately IDENTICAL to dark — the acid lime chip/meter/pill
+       reads the same in both modes because it always carries near-black ink. */
+    --vivid: 74 89% 55%;
+    --vivid-foreground: 80 45% 6%;
+    --vivid-soft: 74 89% 40% / 0.20;
+
+    --elev-recess: inset 0 1px 2px rgba(0,0,0,0.05);
+    --elev-flat:   0 1px 2px rgba(0,0,0,0.05);
+    --elev-raise:  0 4px 16px -4px rgba(0,0,0,0.10), inset 0 1px 0 rgba(255,255,255,0.6);
+    --elev-float:  0 24px 60px -18px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.7);
+    --surface-recess: rgba(60,55,30,0.045);
+
+    --mesh-1: 74 85% 52%;
+    --mesh-2: 165 65% 48%;
+    --mesh-3: 258 65% 62%;
+    --mesh-4: 28 88% 60%;
+    --mesh-ink: 0 0% 100%;
+
+    --hatch-color: rgba(60,55,30,0.20);
+    --hatch-bg: rgba(60,55,30,0.045);
   }
 
   /* ========================================
@@ -539,6 +624,16 @@ All colors MUST be HSL.
     --card-gradient-end: 214 30% 96%;
 
     --brand-gradient: linear-gradient(135deg, #0f2547 0%, #1c5091 46%, #2f6fed 100%);
+
+    /* Keep the data accent in-family — a lime meter inside the blue skin reads
+       as a bug, not a highlight. */
+    --vivid: 212 90% 52%;
+    --vivid-foreground: 0 0% 100%;
+    --vivid-soft: 212 90% 45% / 0.16;
+    --mesh-1: 212 90% 55%;
+    --mesh-2: 190 75% 50%;
+    --mesh-3: 258 70% 62%;
+    --mesh-4: 28 88% 60%;
   }
 
   /* Blue — DARK theme. Shifts the plum-black command center to a deep navy-black
@@ -576,6 +671,14 @@ All colors MUST be HSL.
     --sidebar-border: 217 25% 18%;
 
     --hero-background: 220 34% 9%;
+
+    --vivid: 212 90% 58%;
+    --vivid-foreground: 220 45% 8%;
+    --vivid-soft: 212 90% 58% / 0.16;
+    --mesh-1: 212 90% 58%;
+    --mesh-2: 190 75% 52%;
+    --mesh-3: 258 70% 62%;
+    --mesh-4: 28 88% 60%;
   }
 }
 
@@ -603,6 +706,11 @@ All colors MUST be HSL.
     letter-spacing: -0.01em;
   }
 
+  /* Optical tracking: the larger a heading gets, the tighter it needs to set.
+     Without this a 60px title looks loose and unresolved next to a 44px metric. */
+  h1 { letter-spacing: -0.025em; }
+  h2 { letter-spacing: -0.02em; }
+
   strong, b {
     font-weight: var(--font-medium);  /* Medium weight for emphasis (500) */
   }
@@ -611,28 +719,35 @@ All colors MUST be HSL.
     font-weight: var(--font-normal);  /* Regular weight for body text */
   }
 
-  /* ===== GLOBAL LIGHTER FONT WEIGHT OVERRIDES ===== */
-  /* Make all bold/semibold/medium classes lighter across the entire app */
-  /* This ensures consistency without changing every component manually */
+  /* ===== GLOBAL FONT WEIGHT COMPRESSION (relaxed 2026-08-12) =====
+     These rules used to flatten EVERY emphasis class to 300/400, so the whole
+     app rendered inside a single 300-400 weight band — no `font-bold` anywhere
+     could actually be bold. Combined with a type scale that topped out at 18px
+     for page titles, that is the mechanical reason every screen read as flat.
+
+     They are RELAXED one notch rather than deleted: deleting them would snap
+     866 `font-semibold` and 331 `font-bold` call sites straight to 600/700 in a
+     single commit. One notch restores real hierarchy while keeping the platform's
+     light character. Revert this block alone to restore the old flatness. */
 
   .font-black {
-    font-weight: var(--font-light) !important;  /* 300 instead of 900 */
+    font-weight: 700 !important;  /* was 300 */
   }
 
   .font-extrabold {
-    font-weight: var(--font-light) !important;  /* 300 instead of 800 */
+    font-weight: 700 !important;  /* was 300 */
   }
 
   .font-bold {
-    font-weight: var(--font-light) !important;  /* 300 instead of 700 */
+    font-weight: var(--font-semibold) !important;  /* 600 — was 300 */
   }
 
   .font-semibold {
-    font-weight: var(--font-normal) !important;  /* 400 instead of 600 */
+    font-weight: var(--font-medium) !important;  /* 500 — was 400 */
   }
 
   .font-medium {
-    font-weight: var(--font-normal) !important;  /* 400 instead of 500 */
+    font-weight: var(--font-medium) !important;  /* 500 — was 400 */
   }
 
   /* Hide number input spinners - we use custom +/- buttons instead */
@@ -1485,6 +1600,285 @@ html.light .msg-assistant [class*="border-white"] { border-color: hsl(var(--bord
 html.light .msg-assistant a { color: hsl(var(--primary)); }
 
 /* ============================================================
+   2026 COMMAND-CENTER LANGUAGE
+   ------------------------------------------------------------
+   The vocabulary the redesign is built from. Every class here is
+   theme-token driven, so light/dark/blue all inherit for free.
+   ============================================================ */
+@layer components {
+
+  /* --- MICRO LABEL -----------------------------------------------------
+     The tiny uppercase caption that sits ABOVE a metric. This is what makes a
+     big number read as instrumentation rather than decoration. */
+  .micro-label {
+    font-family: var(--font-sans);
+    font-size: 0.6875rem;          /* 11px */
+    font-weight: 600;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: hsl(var(--muted-foreground));
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  /* --- METRIC ----------------------------------------------------------
+     Oversized numerals. Averta (grotesque) not Aleo (slab) — a slab at 88px
+     reads editorial, not instrumental. Tabular figures so digits do not jitter
+     as values refresh. The !important weights are deliberate: they have to beat
+     the global .font-* compression in the base layer. */
+  .metric {
+    font-family: var(--font-metric);
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum' 1, 'lnum' 1;
+    letter-spacing: -0.04em;
+    line-height: 0.92;
+    color: hsl(var(--foreground));
+    display: inline-flex;
+    align-items: baseline;
+    white-space: nowrap;
+  }
+  .metric-sm { font-size: var(--metric-sm); font-weight: 600 !important; }
+  .metric-md { font-size: var(--metric-md); font-weight: 500 !important; }
+  .metric-lg { font-size: var(--metric-lg); font-weight: 400 !important; }
+  .metric-xl { font-size: var(--metric-xl); font-weight: 300 !important; }
+
+  /* The trailing group of a two-tone numeral (decimals / thousands) drops to a
+     muted tone so the eye lands on the magnitude first — straight from the
+     Business Central reference ("$ 23,876" with 876 in grey). */
+  .metric-trail { color: hsl(var(--muted-foreground)); font-weight: inherit; }
+
+  /* The currency mark / unit rides small and high, never at numeral size. */
+  .metric-affix {
+    font-size: 0.42em;
+    font-weight: 500 !important;
+    color: hsl(var(--muted-foreground));
+    letter-spacing: 0;
+    align-self: flex-start;
+    padding-top: 0.35em;
+  }
+
+  /* --- DISPLAY HEADLINE ------------------------------------------------ */
+  .display-hero {
+    font-family: var(--font-display);
+    font-size: var(--display-lg);
+    line-height: 0.95;
+    letter-spacing: -0.03em;
+    font-weight: 700 !important;
+  }
+  .display-page {
+    font-family: var(--font-display);
+    font-size: var(--display-sm);
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    font-weight: 700 !important;
+  }
+
+  /* --- ELEVATION SURFACES ---------------------------------------------
+     Replaces "every surface is the same glass panel". A recessed panel GROUPS
+     tiles; a raised card holds ONE idea. That distinction is the hierarchy the
+     old system never had. */
+  .surface-recessed {
+    background: var(--surface-recess);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--elev-recess);
+    border: 1px solid transparent;
+  }
+  .surface-raised {
+    background: hsl(var(--card));
+    border-radius: var(--radius-xl);
+    box-shadow: var(--elev-raise);
+    border: 1px solid hsl(var(--border) / 0.6);
+  }
+  .surface-float {
+    background: hsl(var(--card));
+    border-radius: var(--radius-2xl);
+    box-shadow: var(--elev-float);
+    border: 1px solid hsl(var(--border) / 0.5);
+  }
+
+  /* --- MESH CARD -------------------------------------------------------
+     The ONE loud surface per screen. Four blurred radial blobs over a base
+     tint, exactly the "Insights" panel in the reference. Keep it to a single
+     instance per view or it stops being a focal point. */
+  .mesh-card {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    border-radius: var(--radius-2xl);
+    background-color: hsl(var(--mesh-3) / 0.9);
+    background-image:
+      radial-gradient(120% 90% at 8% 8%,    hsl(var(--mesh-4) / 0.95), transparent 55%),
+      radial-gradient(110% 85% at 92% 4%,   hsl(var(--mesh-1) / 0.85), transparent 58%),
+      radial-gradient(120% 95% at 78% 96%,  hsl(var(--mesh-2) / 0.90), transparent 60%),
+      radial-gradient(130% 100% at 15% 92%, hsl(var(--mesh-3) / 0.95), transparent 62%);
+    color: hsl(var(--mesh-ink));
+    box-shadow: var(--elev-float);
+  }
+
+  /* A soft dark scrim over the lower half only, so white copy stays legible
+     wherever the blobs happen to land bright. */
+  .mesh-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background: linear-gradient(180deg, transparent 35%, rgba(0, 0, 0, 0.28) 100%);
+    pointer-events: none;
+  }
+
+  /* --- HATCH BAR -------------------------------------------------------
+     The striped "last period" bar that a solid "this period" bar is compared
+     against. Diagonal stripes read as historic/inactive without a legend. */
+  .hatch-bar {
+    background-color: var(--hatch-bg);
+    background-image: repeating-linear-gradient(
+      -45deg,
+      var(--hatch-color) 0 1px,
+      transparent 1px 6px
+    );
+    border-radius: var(--radius-sm);
+  }
+
+  /* --- CIRCLE ACTION ---------------------------------------------------
+     The round "open this" affordance in a card corner. */
+  .circle-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--radius-full);
+    border: 1px solid hsl(var(--border));
+    color: hsl(var(--muted-foreground));
+    background: transparent;
+    transition: var(--transition-smooth);
+    flex-shrink: 0;
+  }
+  .circle-action:hover {
+    background: hsl(var(--vivid));
+    border-color: hsl(var(--vivid));
+    color: hsl(var(--vivid-foreground));
+    transform: rotate(45deg);
+  }
+
+  /* --- PILL ACTION -----------------------------------------------------
+     The outlined "+ Sales Quote" quick-action row. */
+  .pill-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem 0.5rem 0.6rem;
+    border-radius: var(--radius-full);
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--card) / 0.6);
+    color: hsl(var(--foreground));
+    font-size: var(--text-sm);
+    line-height: 1;
+    white-space: nowrap;
+    transition: var(--transition-smooth);
+  }
+  .pill-action:hover {
+    border-color: hsl(var(--vivid));
+    background: hsl(var(--vivid) / 0.10);
+  }
+
+  /* --- DELTA CHIP ------------------------------------------------------
+     The small +2 / -12% marker riding beside a metric. */
+  .delta-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+    padding: 0.15rem 0.45rem;
+    border-radius: var(--radius-full);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    line-height: 1.35;
+    font-variant-numeric: tabular-nums;
+  }
+  .delta-up   { background: hsl(var(--vivid) / 0.18); color: hsl(var(--vivid)); }
+  .delta-down { background: hsl(var(--error) / 0.16); color: hsl(var(--error)); }
+  .delta-flat { background: hsl(var(--muted));        color: hsl(var(--muted-foreground)); }
+
+  /* In light mode the acid lime is too pale to read as text on its own tint,
+     so the chip borrows the deep-lime primary for its ink. */
+  html.light .delta-up { background: hsl(var(--vivid) / 0.30); color: hsl(var(--primary)); }
+
+  /* --- METER -----------------------------------------------------------
+     The track + fill + dot marker under a KPI (the ClientIQ pattern). */
+  .meter-track {
+    position: relative;
+    height: 4px;
+    border-radius: var(--radius-full);
+    background: hsl(var(--muted-foreground) / 0.18);
+    overflow: visible;
+  }
+  .meter-fill {
+    position: absolute;
+    inset: 0 auto 0 0;
+    border-radius: var(--radius-full);
+    background: hsl(var(--vivid));
+  }
+  .meter-dot {
+    position: absolute;
+    top: 50%;
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-full);
+    background: hsl(var(--foreground));
+    transform: translate(-50%, -50%);
+    box-shadow: 0 0 0 3px hsl(var(--card));
+  }
+
+  /* --- FOLDER TAB ------------------------------------------------------
+     The notched section tab from the reference: the tab and the panel share one
+     surface, joined by a concave corner. The ::after mask carves the inverse
+     radius; because the tab and the panel are both translucent over the same
+     page ground, the rendered colours match exactly. */
+  .tab-notch {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1.5rem 0.85rem 1.5rem;
+    background: var(--surface-recess);
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  }
+  .tab-notch::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 100%;
+    width: 18px;
+    height: 18px;
+    background: var(--surface-recess);
+    -webkit-mask: radial-gradient(circle 18px at 100% 0, transparent 0 18px, #000 18px);
+            mask: radial-gradient(circle 18px at 100% 0, transparent 0 18px, #000 18px);
+    pointer-events: none;
+  }
+  .tab-notch-panel {
+    background: var(--surface-recess);
+    border-radius: 0 var(--radius-xl) var(--radius-xl) var(--radius-xl);
+    box-shadow: var(--elev-recess);
+  }
+
+  /* --- VIVID FILL ------------------------------------------------------
+     The single loud control on a screen (primary CTA, active pill). Always
+     near-black ink on acid lime — never white. */
+  .vivid-fill {
+    background: hsl(var(--vivid));
+    color: hsl(var(--vivid-foreground));
+    border-color: hsl(var(--vivid));
+  }
+  .vivid-fill:hover { background: hsl(var(--vivid) / 0.88); }
+
+  /* Sparkline stroke colours, so the SVG component stays token-driven. */
+  .spark-stroke { stroke: hsl(var(--foreground)); }
+  .spark-stroke-vivid { stroke: hsl(var(--vivid)); }
+}
+
+/* ============================================================
    BRAND GRADIENT ON PRIMARY FILLS — global
    ------------------------------------------------------------
    Every solid `bg-primary` fill (primary buttons, active tabs,
@@ -1503,8 +1897,8 @@ html.light .msg-assistant a { color: hsl(var(--primary)); }
    APP ATMOSPHERE — command-center depth behind every page.
    A fixed brand-aurora mesh + film grain sit over the solid body
    ground and below all page content (main is relative z-10). The
-   aurora is driven by --primary so it adapts per theme: a magenta
-   glow on the plum-black dark ground, a soft olive glow on cream.
+   aurora is driven by --primary so it adapts per theme: an acid-lime
+   glow on the near-black dark ground, a deep-lime glow on cream.
    ============================================================ */
 .app-aurora {
   position: fixed;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,6 +18,20 @@ export default {
 			fontFamily: {
 				sans: ['Averta', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif'],
 				display: ['Aleo', 'Georgia', 'Times New Roman', 'serif'],
+				// Numerals + display metrics. The slab (Aleo) reads editorial at large
+				// sizes; instrumentation wants the grotesque.
+				metric: ['Averta', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
+			},
+			fontSize: {
+				// Display tier — the platform previously topped out at text-4xl (36px),
+				// which is why page titles, card titles and body all sat in one band.
+				'metric-sm': ['1.75rem', { lineHeight: '0.92', letterSpacing: '-0.04em' }],
+				'metric-md': ['2.75rem', { lineHeight: '0.92', letterSpacing: '-0.04em' }],
+				'metric-lg': ['4rem', { lineHeight: '0.92', letterSpacing: '-0.04em' }],
+				'metric-xl': ['5.5rem', { lineHeight: '0.92', letterSpacing: '-0.045em' }],
+				'display-sm': ['2rem', { lineHeight: '1.05', letterSpacing: '-0.025em' }],
+				'display-md': ['2.75rem', { lineHeight: '1', letterSpacing: '-0.028em' }],
+				'display-lg': ['3.75rem', { lineHeight: '0.95', letterSpacing: '-0.03em' }],
 			},
 			colors: {
 				border: 'hsl(var(--border))',
@@ -83,6 +97,14 @@ export default {
 				info: {
 					DEFAULT: 'hsl(var(--info))',
 					foreground: 'hsl(var(--info-foreground))',
+				},
+				// The acid data accent. `--primary` has to stay legible as TEXT in both
+				// themes (1024 `text-primary` call sites cap how acid it can go in light
+				// mode); `vivid` is the uncapped FILL accent — meters, sparklines,
+				// positive deltas, the one primary CTA. Always near-black ink on top.
+				vivid: {
+					DEFAULT: 'hsl(var(--vivid))',
+					foreground: 'hsl(var(--vivid-foreground))',
 				},
 			},
 			borderRadius: {


### PR DESCRIPTION
Applies the layout language from the two reference dashboards (Business Central concept + ClientIQ) across the design system. **The header and app megamenu are untouched**, per the brief.

Scope was agreed up front: **global tokens + primitives** (ripples to all ~700 components), **dark stays default**, **acid-lime accent**, **full-send intensity**.

## The diagnosis — it was not the colours

Four mechanical causes, in order of weight:

1. **No type tier above 36px.** Page titles were `text-lg` (**18px**), `CardTitle` 16px, body 14px. Every screen sat inside one 4px band, so a KPI and a table cell carried identical visual weight and nothing led the eye.
2. **The global weight compression pinned `.font-bold` to 300** and `.font-semibold`/`.font-medium` to 400 with `!important`. Nothing in the app could actually be bold.
3. **One card shape for everything** — 607 `.dashboard-card` hits across 182 files, same glass panel, same radius, same padding, whether the surface held a KPI, a table, or a form.
4. **No data ornament** — a KPI was a bare number and a label.

Both references keep **exactly one loud surface** per screen and let everything else go quiet. The old system was uniformly mid-contrast, so nothing was a focal point.

## Tokens

- **Acid lime accent.** Dark `#c2f231` on a near-black page; light `#47610f` on the oat page. They differ deliberately: **`--primary` has to stay legible as TEXT** — `text-primary` has **1024 call sites in 319 files**, and acid lime on cream is ~1.4:1.
- **New `--vivid`** — the uncapped *fill* accent, identical in both themes, always carrying near-black ink. Meters, sparklines, positive deltas, the one CTA. Never body text. (`bg-vivid` / `text-vivid` in Tailwind.)
- **Display tier**: `--metric-sm/md/lg/xl` (28/44/64/88px) and `--display-sm/md/lg` (32/44/60px).
- **`--radius` 8px → 16px**; elevation ladder (`recess`/`flat`/`raise`/`float`); mesh + hatch tokens.
- The `data-accent="blue"` skin gets in-family vivid/mesh values so a lime meter never appears inside it.

## Primitives

New, all in `@/components/core/DesignSystem`: `Metric` (two-tone numerals), `Sparkline`, `MicroLabel`, `DeltaChip`, `Meter`, `CircleAction`, `StatTile`, `KpiCard` (hatched-previous vs solid-current), `MeshCard`, `QuickActions`, `NotchPanel`/`NotchGroup`.

Upgraded: `Card` gains an `elevation` prop, `PageHeader` moves to the display tier, `StatCard` adopts the metric language.

## Dashboard

Rebuilt as the proof surface: greeting + quick-action pills → headline KPIs → one mesh insight surface → folder-tab Activities panel. **Metrics now lead the page** — it previously opened on a 400px search hero, putting the state of the business below the fold on every laptop. `MyOffice`'s data layer was extracted **verbatim** into `useOfficeData.ts`, so the queries and their carefully-tuned loading semantics are untouched by the presentation rewrite.

## Reviewer notes — highest blast radius first

1. **The weight relaxation** (`GLOBAL FONT WEIGHT COMPRESSION` in `src/index.css`) is the single biggest visual change: it moves 866 `font-semibold` and 331 `font-bold` call sites. It was **relaxed one notch (600/500/500), not deleted** — deleting would have snapped everything to 700 at once. **This block is self-contained: revert it alone to restore the old flatness** without losing anything else.
2. **`--radius` 8px → 16px** re-rounds every `rounded-lg/md/sm` in the app.
3. `--primary` flipping hue affects every `text-primary` / `bg-primary`. `--primary-foreground` is now **near-black** on dark (it must be — white on lime is unreadable).

## Verification

`npm run typecheck` ✅ · **1239/1239 tests pass** ✅ · production `vite build` ✅ · eslint clean on all changed files ✅

Quick-action targets were checked against the router rather than assumed — the platform has **no `/new` routes at all**, and MoodBoards is `/moodboard` (singular), so they point at list pages.

## Not included

`.claude/design-system.md` was updated with the full rationale and a new §16 documenting the language, but **`.claude/` is gitignored**, so that doc is local-only and does not appear in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
