### PR TITLE
A product-UI design system: flat surfaces, hairlines, underline tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 - **Backend**: Python FastAPI (`mivaa-pdf-extractor/`) — **a separate git repo**, mounted as a submodule
 - **Edge Functions**: Deno/TypeScript (`supabase/functions/`)
 - **Database**: Supabase PostgreSQL 15 + pgvector 0.8.0
-- **Design System**: `.claude/design-system.md` — full reference for all UI patterns, colors, components
+- **Design System**: [docs/design-system.md](docs/design-system.md) — full reference for all UI patterns, colors, components. Live specimen: `/design-system` in-app.
 
 ## Workflow Rules
 - **SQL / migrations**: ALWAYS apply via `mcp__supabase__apply_migration` (DDL) or `mcp__supabase__execute_sql`. NEVER create a local `supabase/migrations/*.sql` file. Run `mcp__supabase__get_advisors(security)` after any DDL.
@@ -329,15 +329,27 @@ Tunable via env `SUPABASE_LOG_DENY_PREFIXES` without a deploy. **If you add a ch
 prefix — do not widen retention.**
 
 ## Design System Summary
-Full reference: `.claude/design-system.md`.
-- **Dark** = plum-black command center (`--background: 258 22% 5%`), flat **magenta** primary (`--primary: 335 74% 60%`). **Light** = warm olive/cream (`--background: 42 27% 93%`), muted **khaki-olive** primary, terracotta destructive.
-- **Headings** use **Aleo** (`font-display`); **Averta** for body/UI. Both self-hosted from `public/fonts/`.
+Full reference: [docs/design-system.md](docs/design-system.md). Live specimen: **`/design-system`** in-app.
+Guarded by [tests/unit/designSystem.test.ts](tests/unit/designSystem.test.ts).
+
+The platform runs a **product-UI** language: flat opaque surfaces, hairline separation, dense
+controls, underline tabs, one accent. It replaced a marketing language (glass panels, a brand
+aurora behind every page, pill buttons that lifted on hover) that was being applied to screens
+whose job is showing tables of money.
+
+- **Colour is unchanged**: dark/light modes × green/blue accents, owned by `ThemeContext`. Dark = plum-black + magenta; light = olive/cream (green) or slate + blue. **Every surface must work in all four** — check at `/design-system`, which has the switcher.
+- **Three surfaces, and that is the whole ladder**: `bg-background` (page, FLAT — no gradient, no aurora) → `bg-card` + `border-hairline` (panel) → `bg-surface-sunken` (toolbar / table header / footer). `--hairline` is the ONE rule colour in the app.
+- **A panel is separated by a hairline, not a shadow, and does not move on hover.** Shadow (`shadow-overlay`) is only for things that genuinely float: dropdown, popover, dialog, toast. A panel that is itself a click target gets `panel-interactive`.
+- **`.dashboard-card` / `<Card>` are the panel.** Never recreate one inline. The `--glass-*` tokens kept their names and now hold opaque values, which is why retiring glass did not need a 400-file sweep.
+- **Headings**: Aleo (`font-display`) for `h1`/`h2` — identity only. `h3`–`h6` are sans (`--font-sans`), because a serif in a dense data UI is the loudest possible "this is not a product".
 - **`--font-display` is `'Aleo', 'Averta', Georgia, ...` — do NOT drop Averta.** Aleo has ZERO Greek glyphs and only 24/128 latin-ext, so Greek party names in headings silently fell back to Georgia (absent on Linux). Font matching is per-character, so latin headings still get Aleo. Check any new display face's cmap for U+0370–U+03FF before adopting it.
-- **The brand gradient is reserved for IDENTITY surfaces** (PageHeader, logo, hero). Primary fills are flat accent — the old global "`bg-primary` → brand-gradient" rule was removed.
-- **Glass cards**: use the `.dashboard-card` class. Never recreate inline.
-- **Buttons** are pill-shaped (`rounded-full`). **NEVER add `rounded-full` to a TabsTrigger** — that is Buttons only.
-- **Tables**: `<CardContent className="p-0">`, no wrapper div, no fixed column widths. Status/type render as **plain colored words, never a Badge/pill with a colored background**.
+- **No global font-weight override.** There used to be one (`.font-bold → 300 !important` and friends); it flattened every weight utility so a table header, a total and its caption rendered identically, and it could not be worked around per component. Weight IS the hierarchy here.
+- **Buttons are rectangular** (`rounded-sm`, 4px), 36px tall, flat fill, no lift. **`rounded-full` is for avatars, dots and status pips only** — never a button, a tab or a chip. One solid button per screen; its partner is `secondary` (accent outline), everything else is `outline`/`ghost`.
+- **Tabs are UNDERLINE, platform-wide** — the treatment is in `index.css` on `[role="tab"]`, so it reaches Radix Tabs, `HubTabNav` and every hand-rolled strip. Never a filled pill: that is the exact silhouette of a primary button, so "where I am" and "what to press" become the same object.
+- **Tables**: sticky sunken header, hairline row separators, NO zebra striping, 11px semibold headers (never uppercase), right-aligned `tabular-nums` for money, an explicit empty state, `—` for an absent value. Status renders as a **tinted squared tag** (`<Badge variant="success|warning|error|info|neutral">`) — tinted, never a saturated fill, which would give every row the weight of a button.
 - **A table in a Card gets its title + subtitle + actions inside a `CardHeader`** — never a bare heading above a header-less Card.
+- **Screen archetypes live in `src/components/core/hub/`** — `HubDataTable` + `HubToolbar` (list), `HubRecordLayout` (record), `HubStatGrid` (dashboard), `HubSideNav` (settings). Build the archetype; do not re-derive it per page.
+- **Never use an off-scale opacity modifier** (`bg-white/8`, `border-white/12`). Tailwind only emits opacity variants for steps in `theme.opacity` (0,5,10,…,100); anything else compiles to NOTHING. The platform carried 74 of them, including 31 borders and 25 row dividers that had never rendered in dark mode. Use a token, or `bg-primary/[0.08]`.
 - **English is the default for all UI and documents.** Never default a language field to `'el'`.
 
 ## Where the rest lives

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -323,7 +323,7 @@ Complete documentation for Material Kai Vision Platform.
 
 ### 🏗️ Architecture & Design
 
-**[design-system.md](design-system.md)** - Dark-mode theme, horizontal top nav, typography, button/tab/card/table patterns, image optimization helper. Summary + pointer to full reference at `.claude/design-system.md`.
+**[design-system.md](design-system.md)** - The full design system: tokens, surfaces, typography, primitives, the `hub/` pattern library, the three screen archetypes, and the image optimization helper. Live specimen sheet at `/design-system` in-app.
 
 **[category-field-registry.md](category-field-registry.md)** - Frontend display config for the 10 material categories (`tiles`, `wood`, `decor`, `furniture`, `general_materials`, `paint_wall_decor`, `heating`, `sanitary`, `kitchen`, `lighting`). How sections render in `ProductDetailModal`, `controlledVocab` resolution, editing rules, drift-with-Python warnings.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,113 +1,370 @@
-# Design System
+# Material KAI Vision Platform — Design System
 
-The full reference lives at `.claude/design-system.md` (1060 lines — every token, component, pattern). It is **not linkable from here — `.claude/` is gitignored**, so open it from a local checkout. This doc is the high-level summary plus the most recent layout/theme changes that anyone touching the UI needs to know.
-
----
-
-## Theme — Dark mode
-
-The platform shipped a dark-theme migration in April 2026. All components assume a near-black background and light foreground.
-
-| Token | HSL | Hex (approx) | Use |
-|-------|-----|--------------|-----|
-| `--background` | `0 0% 7%` | `#121212` | App background |
-| `--foreground` | `0 0% 92%` | `#ebebeb` | Default text |
-| `--primary` | `330 50% 35%` | brightened plum | CTA buttons, active tab background, links |
-| `--primary-foreground` | `0 0% 98%` | near-white | Text on primary surfaces |
-| `--accent` | `22 60% 18%` | dark warm brown | Hover surfaces, secondary highlights |
-| `--card` (glass) | `rgba(255,255,255,0.05)` + `backdrop-filter: blur(12px)` | — | All admin/dashboard cards |
-
-The old beige/light theme is gone. There is no light mode toggle.
+> **Single source of truth for visual decisions.** Change a token here, it changes everywhere.
+>
+> **Live specimen: [`/design-system`](../src/pages/DesignSystemPage.tsx)** — every surface below,
+> rendered with the real components and the real tokens, with a light/dark × green/blue switcher.
+> When this file and that page disagree, **the page is right and this file is stale** — fix the file.
 
 ---
 
-## Layout — Floating glass top nav (desktop) + drawer (mobile)
+## 0. What changed, and why (2026-08-18)
 
-The previous left sidebar was replaced with a horizontal top navigation in the April 2026 redesign.
+The platform was rebuilt onto a **product-UI** language modelled on HubSpot: flat opaque surfaces,
+hairline separation, dense controls, underline tabs, one accent. What it replaced was a
+**marketing** language — glass panels, a brand aurora behind every page, pill buttons that lifted
+on hover, a gradient header band — applied to screens whose actual job is showing tables of money.
+
+The colour system did **not** change: dark/light modes and the green/blue accents are exactly as
+they were. Neither did the top nav or the apps mega-menu.
+
+Five changes carry most of the difference. Each is here because the old version cost something
+concrete, not because it looked dated:
+
+| Change | What it cost before |
+|---|---|
+| **Glass → opaque panels** | A translucent panel has no fixed contrast ratio: text legibility depended on what scrolled underneath it, so the same table was compliant in one scroll position and marginal in another. No static audit can catch that. |
+| **Aurora canvas → flat `--background`** | An opaque panel can only match a flat ground, and every chart, KPI and table lost contrast against the moving gradient. `background-attachment: fixed` also repainted the full viewport on every scroll frame. |
+| **Filled-pill tabs → underline tabs** | A filled accent pill is the exact silhouette of a primary button. "The section you are in" and "the button to press" were the same object on every record page. |
+| **Pill buttons → 4px rectangles** | Buttons, status chips, filter chips and active tabs were all pills. A toolbar had no grammar — you had to read every element to find out which ones did something. |
+| **Global weight override removed** | `.font-bold → 300`, `.font-semibold → 400`, `.font-medium → 400`, with `!important`. A table header, a total, a KPI and its caption all rendered at one weight. In a dense data UI, weight *is* the hierarchy. |
+
+**Migration is by token, not by sweep.** `--glass-background`, `--glass-border`, `--glass-blur`
+and `--glass-shadow` kept their names and were repointed at opaque values, so ~400 call sites of
+`.dashboard-card` changed material without being edited. `.glass-panel`, `.gradient-border`,
+`.tinted-card`, `.tabs-underline`, `.glow-*`, `.app-aurora` and `.app-grain` all still resolve —
+as the new thing, or as an inert no-op. Nothing needs a find-and-replace to keep compiling.
+
+---
+
+## Table of Contents
+
+1. [Colour](#1-colour)
+2. [Surfaces & elevation](#2-surfaces--elevation)
+3. [Typography](#3-typography)
+4. [Spacing, radius, density](#4-spacing-radius-density)
+5. [Primitives](#5-primitives)
+6. [Patterns (the `hub/` library)](#6-patterns-the-hub-library)
+7. [The three screen archetypes](#7-the-three-screen-archetypes)
+8. [Navigation](#8-navigation)
+9. [Do / Don't](#9-do--dont)
+10. [New page checklist](#10-new-page-checklist)
+11. [Image optimization](#11-image-optimization)
+12. [Reference files](#12-reference-files)
+
+---
+
+## 1. Colour
+
+Two **modes** (`html.light` / `html.dark`) × two **accents** (`html[data-accent='green'|'blue']`),
+both owned by `ThemeContext` and persisted per user. Four combinations; every surface must work in
+all four. The specimen page has the switcher for exactly this reason.
+
+### Core tokens
+
+| Token | Dark (green) | Light (green) | Meaning |
+|---|---|---|---|
+| `--background` | `258 22% 5%` | `42 27% 93%` | The page. One flat colour, no gradient. |
+| `--card` | `266 22% 8%` | `48 30% 97%` | A panel. One step up from the page. |
+| `--surface-sunken` | `262 22% 10%` | `44 24% 91%` | Table headers, toolbars, footers — one step *down*. |
+| `--surface-hover` | `264 20% 12%` | `44 24% 90%` | Row / list-item / interactive-panel hover. |
+| `--hairline` | `260 16% 18%` | `46 18% 82%` | **Every** rule, border and separator in the app. |
+| `--primary` | `335 74% 60%` | `56 24% 37%` | The accent. Fills, links, active states, focus. |
+| `--foreground` | `280 15% 93%` | `46 14% 21%` | Body ink. |
+| `--muted-foreground` | `258 14% 60%` | `48 16% 38%` | Labels, captions, table headers, empty values. |
+
+The **blue** accent retints the same set (`html.light[data-accent='blue']`, `html.dark[data-accent='blue']`):
+a cool slate page with white cards on light, a navy-black command centre on dark.
+
+### Semantic colour
+
+`--success` / `--warning` / `--error` / `--info`, each with a `-bg` tint and a `-foreground`.
+Status is **tinted**, never a saturated fill (see [Badge](#badge)).
+
+**Never colour by direction alone.** A rising number is not automatically green — see
+`HubStatTile`'s `upIsGood`. And never let colour be the *only* signal: deltas carry an arrow,
+status tags carry a word, validation carries text.
+
+### Rules
+
+- ✅ `bg-card`, `text-muted-foreground`, `border-hairline`, `bg-surface-sunken`
+- ❌ `bg-gray-800`, `text-white`, `border-white/10`, `#1f2937` — a hardcoded colour is wrong in
+  at least two of the four theme combinations, by construction.
+- ❌ **Non-scale opacity modifiers.** `bg-white/8`, `border-white/12` and friends do not exist in
+  Tailwind's default opacity scale, so they compile to **nothing**. The app is full of them and
+  they have silently done nothing in dark mode for a long time. Use a token, or an arbitrary
+  value (`bg-primary/[0.08]`) if you genuinely need an off-scale alpha.
+
+---
+
+## 2. Surfaces & elevation
+
+Three surfaces. That is the whole ladder.
 
 ```
-   m-4 ─────────────────────────────────────────────────────────────
-  ┌───────────────────────────────────────────────────────────────┐
-  │ [Logo] [Search …]                          [Profile menu]     │   h-20, rounded-3xl
-  │  glass-panel · bg-white/5 · border-white/8 · sticky top-0     │   floating, not flush
-  └───────────────────────────────────────────────────────────────┘
-                              Page content
+page      bg-background       flat, no gradient, no texture
+panel     bg-card             + border-hairline + rounded-md
+sunken    bg-surface-sunken   inside a panel: toolbar, table header, footer
 ```
 
-- **Header height**: `h-20` (80px), sticky, with `m-4 rounded-3xl` so it floats as a glass card rather than touching screen edges
-- **Style**: `glass-panel bg-white/5 border border-white/8` (matches `.dashboard-card` aesthetic)
-- **Logo**: left-aligned, `w-10 h-10 rounded-2xl` icon container
-- **Search bar**: centered, `max-w-xl h-12`
-- **Profile/account menu**: right-aligned, `h-10 w-10 rounded-full` avatar trigger
-- **Admin pages**: accessed via the `/admin` landing page (a grid of feature boxes), not a separate left rail
+**A panel is separated by a hairline, not by a shadow.** Shadow is reserved for things that
+genuinely float above the page: dropdown, popover, dialog, sheet, toast. Those use
+`shadow-overlay` (and `shadow-xl`/`shadow-2xl` are aliased to it, so a stray call site cannot
+invent a heavier one).
 
-Components: [`src/components/core/Header.tsx`](../src/components/core/Header.tsx) for desktop. [`src/components/core/Sidebar.tsx`](../src/components/core/Sidebar.tsx) is still a real component but only renders as a mobile `Sheet` drawer (triggered by a hamburger button on small screens) — desktop users never see it. Don't add new desktop sidebar UI.
-
----
-
-## Typography
-
-- **Font**: Open Sans
-- **Global weight remap** (intentional — headings are light by design):
-  - `font-bold` → 300
-  - `font-semibold` → 400
-  - `font-medium` → 400
-- Don't fight the remap with inline `style={{ fontWeight: ... }}` — change the design instead.
-
----
-
-## Buttons
-
-All buttons are pill-shaped (`rounded-full`). Variants: `default` (plum), `outline`, `secondary`, `ghost`, `destructive`, `link`.
-
-> **Common mistake**: do **not** add `rounded-full` to `TabsTrigger`. Pill shape is for buttons only — tabs use the standard rounded-md.
-
----
-
-## Tabs
+**A panel does not move on hover.** The old card lifted 2px and lightened its whole surface, which
+rippled every dashboard as the mouse crossed it and fought the row highlight on any panel wrapping
+a table. A panel that is *itself* a click target gets `panel-interactive` (or just wrap it in an
+`<a>`/`<button>`, which the CSS picks up): border goes accent, background goes to `--surface-hover`,
+nothing translates.
 
 ```tsx
-<TabsList className="w-full h-auto flex-wrap justify-start gap-2 bg-transparent p-0">
-  <TabsTrigger
-    className="flex items-center gap-2 data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
-  >
-    Tab name
-  </TabsTrigger>
-</TabsList>
-```
-
-Active tab uses `--primary` background. No pill, no underline.
-
----
-
-## Cards
-
-Use the `.dashboard-card` utility class — it bundles the glass effect (rgba white 0.05 + blur 12px on dark background). Never recreate the styling inline.
-
-```tsx
-<div className="dashboard-card p-6">…</div>
+<Card>…</Card>                              // the primitive
+<div className="dashboard-card">…</div>     // the CSS class — identical material
+<div className="panel-interactive …">…</div>// a panel you click through on
 ```
 
 ---
 
-## Tables
+## 3. Typography
 
-```tsx
-<Card>
-  <CardContent className="p-0">
-    <Table>…</Table>
-  </CardContent>
-</Card>
+**Aleo** (`font-display`) for identity. **Averta** (`font-sans`) for everything else. Both
+self-hosted from `public/fonts/`.
+
+```
+h1, h2      font-display  — page titles, hero copy, marketing
+h3–h6       font-sans     — card titles, section headers, panel headers
 ```
 
-Rules:
-- `<CardContent className="p-0">` — no inner padding around the table
-- No wrapper div around the `<Table>`
-- No fixed column widths — let Radix/Tailwind size naturally
+Chrome is sans on purpose. A serif in a dense data UI is the loudest possible "this is not a
+product"; the brand still lands on every page title, which is where it belongs.
+
+> `--font-display` is `'Aleo', 'Averta', Georgia, …` and **Averta must stay in second position.**
+> Aleo's cmap has zero Greek glyphs, so Greek names in headings fell through to Georgia — a font
+> not installed on Linux. Font matching is per-character, so latin headings still get Aleo.
+
+### Scale
+
+| Role | Size | Weight | Notes |
+|---|---|---|---|
+| Page title | 20px | 600 | `PageHeader` only. One per screen. |
+| Section | 16px | 600 | `SectionHeader` — the lead-in for a tab or region. |
+| Panel title | 14px | 600 | `CardTitle`. Do **not** override its size. |
+| Body | 14px | 400 | The default. |
+| Caption / label | 12px | 400–600 | Property labels, helper text, footers. |
+| Table header | 11px | 600 | Muted. **Never uppercase** — uppercase destroys word shape, which is the cue you use to find a column. |
+
+Weight utilities mean what they say. There is **no** global weight override any more; do not
+reintroduce one. If something reads too heavy, change that component.
 
 ---
 
-## Image optimization
+## 4. Spacing, radius, density
+
+```
+--radius-xs  2px   tag, checkbox
+--radius-sm  4px   button, input, select, filter chip
+--radius-md  6px   card, panel, table container   ← `rounded-lg` and `rounded-md` both land here
+--radius-lg  8px   dropdown, popover, tooltip
+--radius-xl 10px   dialog, sheet
+--radius-full      avatars, dots, status pips — and nothing else
+```
+
+Tailwind's `rounded-xl` / `2xl` / `3xl` are **overridden** to 8 / 10 / 12px. They are used on
+hundreds of containers, and at Tailwind's defaults (12/16/24px) a data panel was rounded harder
+than an OS window.
+
+**Control height is 36px** (`h-9`) — button, input, select, textarea row. `sm` is 32px for inside
+a table row; `lg` is 40px for a page's single hero CTA. The old 44px default was a touch target
+standing in for a desktop control, and it set the height of every table row that carried an action.
+
+**Density:** page padding 24px, grid gap 16px, panel padding 20px, table cell 12px × 10px.
+
+---
+
+## 5. Primitives
+
+`src/components/core/ui/*`. Radix + CVA. Read the file header before changing one — each carries
+the reasoning for its shape.
+
+### Button
+
+| Variant | Use |
+|---|---|
+| `default` | The **one** primary action on a screen. Solid accent. |
+| `secondary` | Its partner. Accent outline. |
+| `outline` | Everything else. Neutral hairline. |
+| `ghost` | Icon buttons, table-row chrome, toolbar affordances. |
+| `destructive` | Delete/void. Solid, and rare. |
+| `link` | Inline text action. |
+
+Sizes: `sm` 32 · `default` 36 · `lg` 40 · `icon` 36² · `icon-sm` 32².
+
+If a screen has two solid buttons, one of them is wrong.
+
+### Badge
+
+Squared (2px), 11px, **tinted not filled** for every semantic variant: pale background, deep text,
+matching hairline. A saturated fill has the visual weight of a primary button, so a status column
+turned a table into a table with a button in every row. `default` (solid accent) survives for the
+one case that wants weight — a count badge on a nav item.
+
+Variants: `default` `secondary` `outline` `success` `warning` `error` `info` `high` `medium` `low` `neutral`.
+
+### Input / Select / Textarea
+
+Identical height, radius, fill, border and focus treatment. Focus = accent border + a 3px accent
+halo (`ring-[3px] ring-primary/20`). A form row mixing a 40px input with a 36px select is the most
+common way a settings page looks broken.
+
+### Checkbox
+
+Neutral hairline when unchecked (an accent outline on an empty box reads as *selected*), accent
+fill when checked, and a **dash — not a tick — when indeterminate**. Radix renders `Indicator` for
+both states; without the distinct glyph, "some rows selected" and "all rows selected" look the same
+right before a bulk delete.
+
+### Tabs
+
+**Underline, platform-wide.** The treatment lives in `index.css` keyed on `[role="tab"]`, so it
+reaches Radix `<Tabs>`, `HubTabNav`, the Finance vertical rail and any hand-rolled strip that
+reports itself as a tablist. A vertical list gets the indicator on its leading edge instead.
+
+Opt out with `data-variant="pill"` on the list — there is currently no good reason to.
+
+### Table
+
+Sticky sunken header · hairline row separators · no zebra striping (it consumes the one channel a
+table needs free: the row's own status colour) · 11px semibold headers · right-aligned
+`tabular-nums` for numbers.
+
+Never wrap a table in `overflow-hidden` — `<main>` already clips, so the right-hand columns vanish
+on a narrow viewport with no scrollbar and no swipe. Guarded by
+[tests/unit/responsiveTableOverflow.test.ts](../tests/unit/responsiveTableOverflow.test.ts).
+
+---
+
+## 6. Patterns (the `hub/` library)
+
+`src/components/core/hub/` holds what the primitives compose into. The split matters: a `<Table>`
+cannot know that money aligns right, that a filtered-empty list must not offer a create button, or
+that a record page has three columns with three different jobs. Those rules live here, once.
+
+| Component | What it is |
+|---|---|
+| `HubToolbar` | The sunken band above a list: search left, filters left, actions right. |
+| `HubFilterSelect` | A filter chip. **Turns accent when active** — a list showing 3 of 400 rows otherwise just looks like a list with 3 rows. |
+| `HubDataTable` | Selection, sorting, skeleton rows, empty state, footer band. Generic over the row type. |
+| `HubCellLink` / `HubCellEmpty` | The one accent entry point per row; and the em dash that says "no value" rather than "render failed". |
+| `HubRecordLayout` | The three-column record shell. |
+| `HubRecordIdentity` | Avatar + name + role + quick actions, top of the left rail. |
+| `HubPanel` | A rail panel, optionally collapsible. 12px semibold header — a record page carries 8–12 of these. |
+| `HubProperty` / `HubPropertyList` | Stored fields. Stacked by default: a side-by-side pair in a 300px rail truncates every email address. |
+| `HubTimeline` + `Group` + `Item` | The activity feed. Grouped, because 200 undifferentiated events answer "what happened here" with "everything, equally". |
+| `HubStatTile` / `HubStatGrid` | KPI tile with a meaning-coloured delta; auto-fitting grid (no orphan tile on the last row). |
+| `HubSideNav` | The settings / section rail. Active row = tint + leading accent bar. |
+| `HubTabNav` | Underline tabs for routes and saved views. Route tabs are real `<a>`s — middle-click and ⌘-click are how people use a tab strip. |
+| `HubEmptyState` | Two variants, because "you have none" and "your filters excluded all 4,000" need opposite offers. |
+
+---
+
+## 7. The three screen archetypes
+
+Almost every screen here is one of three. Build the archetype, don't reinvent it.
+
+### List screen
+
+```
+PageHeader (+ HubTabNav for saved views)
+└── one bordered panel
+    ├── HubToolbar   search · filters · actions
+    ├── HubDataTable
+    └── footer       count / bulk actions / pagination
+```
+
+The toolbar and the table are **one object**, not two stacked cards. Three cards down a list screen
+gives you three white boxes with two gutters of dead space between them.
+
+### Record screen
+
+```
+PageHeader
+└── HubRecordLayout
+    ├── left    WHO/WHAT is this        identity + property panels   (300px)
+    ├── centre  WHAT HAPPENED           tabs + timeline              (fluid)
+    └── right   WHAT IT CONNECTS TO     deals, files, companies      (300px)
+```
+
+Rails are fixed-width because they hold label/value pairs; the centre is fluid because it holds
+prose. Below `lg` it stacks in that order, which is also decreasing usefulness on a phone.
+
+### Dashboard / report screen
+
+```
+PageHeader
+├── HubStatGrid    the numbers
+└── panels         charts and tables, each with a CardHeader
+```
+
+---
+
+## 8. Navigation
+
+**The top nav and the apps mega-menu are deliberately unchanged in structure.** Only their state
+treatment moved onto the system: an active nav item is a tinted item with accent text, not a solid
+accent pill — same rule as tabs, for the same reason. The bar is opaque (a backdrop blur over a
+flat canvas blurs nothing and still costs a compositor pass per scroll frame) and 48px tall.
+
+Side rails (`HubSideNav`, `.sidebar-item`) mark the active row with a 3px leading accent bar.
+
+---
+
+## 9. Do / Don't
+
+**Surfaces**
+- ✅ `bg-card` + `border-hairline` + `rounded-md`
+- ❌ `backdrop-blur`, translucent panel fills, `shadow-lg` on a resting card, hover lift on a panel that is not a link
+
+**Colour**
+- ✅ tokens, always
+- ❌ `bg-gray-*`, `text-white`, hex literals, `bg-white/8`-style off-scale opacity (compiles to nothing)
+
+**Shape**
+- ✅ 4px buttons, 2px tags, 6px panels, `rounded-full` only for avatars/dots
+- ❌ `rounded-full` on a button, a tab, or a status chip
+
+**Tabs**
+- ✅ underline
+- ❌ a filled pill — that is what a button looks like
+
+**Tables**
+- ✅ sticky header, hairline rows, right-aligned `tabular-nums` money, an explicit empty state
+- ❌ zebra stripes, `overflow-hidden` wrappers, an empty `<td>`, a status rendered as a solid pill
+
+**Type**
+- ✅ weight for hierarchy; serif for h1/h2 only
+- ❌ a global weight override; `text-*` overrides on `CardTitle`; uppercase table headers
+
+**Money & dates** — orthogonal to design but caught by CI on every page:
+`formatMoney` from `@/utils/decimal`, `todayLocalISO()` from `@/utils/datetime`. Never a local
+re-implementation of either, not even in a demo page.
+
+---
+
+## 10. New page checklist
+
+1. `<PageHeader icon title subtitle breadcrumbs actions />` — one per page.
+2. Pick an archetype from §7 and use its `hub/` components.
+3. Every colour from a token. No `text-white`, no `bg-gray-*`, no hex.
+4. Controls at `h-9`; one solid button.
+5. Tables: sortable headers, an empty state, right-aligned numbers.
+6. Check it in **all four** theme combinations at `/design-system`.
+7. Check it at 375px wide — wide tables scroll, they do not clip.
+8. `npm run lint && npm run typecheck && npm test`.
+
+---
+
+## 11. Image optimization
 
 All Supabase Storage image URLs should be passed through [`getOptimizedImageUrl()`](../src/utils/imageOptimization.ts) before rendering. This appends Supabase imgproxy query params (`width`, `quality`, `format=origin`) so the storage layer returns a transformed image instead of the full original.
 
@@ -143,8 +400,18 @@ Used by: `ProductCard`, `SearchResultCard`, `MoodBoardDetailPage`, `ProgressiveI
 
 ---
 
-## Related
+---
 
-- `.claude/design-system.md` — full token reference and component recipes (local checkout only; `.claude/` is gitignored)
-- [`src/index.css`](../src/index.css) — CSS variable definitions
-- [CLAUDE.md](../CLAUDE.md) — "Design System Summary" section
+## 12. Reference files
+
+| File | Holds |
+|---|---|
+| [src/index.css](../src/index.css) | Tokens, surface classes, tab treatment, canvas |
+| [tailwind.config.ts](../tailwind.config.ts) | Radius scale, shadow scale, surface/hairline colours |
+| [src/components/core/ui/](../src/components/core/ui/) | Primitives |
+| [src/components/core/hub/](../src/components/core/hub/) | Patterns |
+| [src/components/shared/PageHeader.tsx](../src/components/shared/PageHeader.tsx) | Page identity band |
+| [src/components/shared/SectionHeader.tsx](../src/components/shared/SectionHeader.tsx) | Section lead-in |
+| [src/pages/DesignSystemPage.tsx](../src/pages/DesignSystemPage.tsx) | The live specimen sheet |
+| [tests/unit/designSystem.test.ts](../tests/unit/designSystem.test.ts) | The guard — what would silently undo this |
+| [src/utils/imageOptimization.ts](../src/utils/imageOptimization.ts) | `getOptimizedImageUrl` (§11) |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,6 +144,8 @@ const PrivacyPolicyPage = lazy(() => import('./pages/legal/PrivacyPolicyPage'));
 const TermsOfServicePage = lazy(() => import('./pages/legal/TermsOfServicePage'));
 const HomePage = lazy(() => import('./pages/HomePage'));
 const ChangelogPage = lazy(() => import('./pages/ChangelogPage'));
+// Live specimen sheet for the design system — see src/components/core/hub/.
+const DesignSystemPage = lazy(() => import('./pages/DesignSystemPage'));
 
 // Module system — registers module routes declared in src/modules/*/index.ts
 import { buildModuleRoutes } from './modules/_core';
@@ -211,6 +213,11 @@ const App = () => (
                     read is useless to the two audiences that need it (prospects and API consumers).
                     Only published rows are reachable; the RLS policy enforces that for anon too. */}
                 <Route path="/changelog" element={<PageErrorBoundary name="Changelog"><ChangelogPage /></PageErrorBoundary>} />
+                {/* Design-system specimen sheet. Deliberately outside AuthGuard: it renders no
+                    real data (every row on it is a literal in the file), and a design reference
+                    you have to hold a workspace seat to look at is the kind of reference that
+                    stops being consulted and then stops being true. */}
+                <Route path="/design-system" element={<PageErrorBoundary name="Design System"><DesignSystemPage /></PageErrorBoundary>} />
                 {/* Public legal pages — no auth required */}
                 <Route path="/privacy" element={<PageErrorBoundary name="Privacy Policy"><PrivacyPolicyPage /></PageErrorBoundary>} />
                 <Route path="/terms" element={<PageErrorBoundary name="Terms of Service"><TermsOfServicePage /></PageErrorBoundary>} />

--- a/src/components/Admin/GlobalAdminHeader.tsx
+++ b/src/components/Admin/GlobalAdminHeader.tsx
@@ -20,7 +20,7 @@ export const GlobalAdminHeader: React.FC<GlobalAdminHeaderProps> = ({
   const navigate = useNavigate();
 
   return (
-    <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-white/8">
+    <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-hairline">
       <div className="flex items-center justify-between gap-4">
         {/* Left: icon + title */}
         <div className="flex items-center gap-3">

--- a/src/components/core/DesignSystem/DashboardCard.tsx
+++ b/src/components/core/DesignSystem/DashboardCard.tsx
@@ -29,10 +29,10 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
   return (
     <div className={cn('dashboard-card', !hover && 'hover:transform-none hover:shadow-card', className)}>
       {(title || subtitle || action) && (
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center justify-between gap-3 mb-3">
           <div>
-            {title && <h3 className="text-lg font-semibold text-foreground">{title}</h3>}
-            {subtitle && <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>}
+            {title && <h3 className="text-sm font-semibold text-foreground">{title}</h3>}
+            {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
           </div>
           {action && <div>{action}</div>}
         </div>

--- a/src/components/core/DesignSystem/StatCard.tsx
+++ b/src/components/core/DesignSystem/StatCard.tsx
@@ -37,8 +37,8 @@ export const StatCard: React.FC<StatCardProps> = ({
     <div className={cn('stat-card', className)}>
       <div className="flex items-start justify-between">
         <div className="flex-1">
-          <p className="text-sm text-muted-foreground mb-2">{title}</p>
-          <p className="text-2xl font-light text-foreground">{value}</p>
+          <p className="text-xs font-semibold text-muted-foreground mb-1.5">{title}</p>
+          <p className="text-2xl font-semibold tabular-nums tracking-tight text-foreground">{value}</p>
           {change && (
             <div className="mt-2">
               <span
@@ -55,8 +55,8 @@ export const StatCard: React.FC<StatCardProps> = ({
           )}
         </div>
         {Icon && (
-          <div className={cn('p-3 rounded-lg bg-secondary/50', iconColor)}>
-            <Icon className="w-6 h-6" />
+          <div className={cn('p-2 rounded-sm bg-surface-sunken', iconColor)}>
+            <Icon className="w-4 h-4" />
           </div>
         )}
       </div>

--- a/src/components/core/Layout.tsx
+++ b/src/components/core/Layout.tsx
@@ -14,10 +14,12 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
   // under the browser toolbar with no way to scroll it into view. `100dvh`
   // tracks the visible viewport; `h-screen` stays as the fallback.
   return (
-    <div className="relative h-screen h-[100dvh] overflow-hidden flex flex-col">
-      {/* Command-center atmosphere — brand aurora + film grain behind every page. */}
-      <div className="app-aurora" aria-hidden="true" />
-      <div className="app-grain" aria-hidden="true" />
+    <div className="relative h-screen h-[100dvh] overflow-hidden flex flex-col bg-background">
+      {/* The two atmosphere layers that used to sit here (a fixed brand "aurora"
+          of radial glows plus a film-grain overlay) are gone. A data product's
+          ground has to be ONE colour: an opaque panel can only match a flat
+          canvas, and a chart, a table and a KPI all lose contrast against a
+          moving gradient. See the APP CANVAS note in index.css. */}
       {/* Skip link — the platform had none anywhere across 640 components, so a keyboard user
           tabbed the ENTIRE sidebar on every route change before reaching content. Visually
           hidden until focused, which is the point: invisible to mouse users, the first stop for

--- a/src/components/core/MobileBottomNav.tsx
+++ b/src/components/core/MobileBottomNav.tsx
@@ -95,7 +95,7 @@ export const MobileBottomNav: React.FC = () => {
         // z-40, NOT z-50: dialogs/overlays (Radix + the agent's custom pickers)
         // all sit at z-50 and the nav is painted after <main>, so at equal z it
         // covered the bottom ~56px of every modal on mobile.
-        className="mobile-bottom-nav fixed bottom-0 inset-x-0 z-40 md:hidden bg-sidebar/95 backdrop-blur-lg border-t border-white/8"
+        className="mobile-bottom-nav fixed bottom-0 inset-x-0 z-40 md:hidden bg-sidebar/95 backdrop-blur-lg border-t border-hairline"
       >
         {/* Each cell keeps a full-width tap target (thumb reach) but its VISUAL
             weight is constrained to a centred pill, so a 5-across bar reads
@@ -164,7 +164,7 @@ export const MobileBottomNav: React.FC = () => {
             "Interior Design") that were being mangled in 4 columns. */}
         <SheetContent
           side="bottom"
-          className="max-h-[80vh] overflow-y-auto rounded-t-2xl bg-sidebar border-t border-white/8 pb-[max(1.5rem,env(safe-area-inset-bottom))]"
+          className="max-h-[80vh] overflow-y-auto rounded-t-2xl bg-sidebar border-t border-hairline pb-[max(1.5rem,env(safe-area-inset-bottom))]"
         >
           <SheetHeader className="text-left">
             <SheetTitle className="font-light">Menu</SheetTitle>

--- a/src/components/core/MobileInstallButton.tsx
+++ b/src/components/core/MobileInstallButton.tsx
@@ -38,7 +38,7 @@ export const MobileInstallButton: React.FC<MobileInstallButtonProps> = ({ onDone
   };
 
   return (
-    <div className="mt-3 border-t border-white/8 pt-3">
+    <div className="mt-3 border-t border-hairline pt-3">
       <button
         type="button"
         onClick={handleClick}

--- a/src/components/core/Sidebar.tsx
+++ b/src/components/core/Sidebar.tsx
@@ -32,10 +32,10 @@ const ShowPricesToggle: React.FC = () => {
       onClick={() => toggle()}
       title={showPrices ? 'Prices shown — click to hide (demo / research mode)' : 'Prices hidden — click to show'}
       aria-pressed={!showPrices}
-      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs text-muted-foreground hover:bg-primary hover:text-primary-foreground transition-colors"
+      className="flex items-center gap-1.5 px-2 py-1.5 rounded-sm text-xs text-muted-foreground hover:bg-surface-hover hover:text-foreground transition-colors"
     >
       {showPrices ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-      <span className="font-light hidden lg:inline">{showPrices ? 'Prices' : 'Prices hidden'}</span>
+      <span className="hidden lg:inline">{showPrices ? 'Prices' : 'Prices hidden'}</span>
     </button>
   );
 };
@@ -83,14 +83,14 @@ export const Sidebar: React.FC = () => {
           aria-label="Profile"
           // min-h-9/min-w-9 on mobile: the label is `hidden md:inline`, so this
           // was a 28x32 icon-only hit area for the primary account entry point.
-          className={`flex min-h-9 min-w-9 items-center justify-center gap-2 px-2 py-1.5 rounded-lg text-sm transition-all duration-200 md:min-h-0 md:min-w-0 md:px-3 ${
+          className={`flex min-h-9 min-w-9 items-center justify-center gap-2 px-2 py-1.5 rounded-sm text-sm transition-colors duration-100 md:min-h-0 md:min-w-0 md:px-2.5 ${
             isActive('/profile')
-              ? 'bg-primary text-primary-foreground'
-              : 'text-muted-foreground hover:bg-primary hover:text-primary-foreground'
+              ? 'bg-primary/[0.12] text-primary font-semibold'
+              : 'text-muted-foreground hover:bg-surface-hover hover:text-foreground'
           }`}
         >
           {accountAvatar('h-5 w-5')}
-          <span className="font-light hidden md:inline">{profile.full_name || 'Profile'}</span>
+          <span className="hidden md:inline">{profile.full_name || 'Profile'}</span>
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56 rounded-xl" align="end" forceMount>
@@ -134,14 +134,14 @@ export const Sidebar: React.FC = () => {
   ) : (
     <Link
       to="/profile"
-      className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-all duration-200 ${
+      className={`flex items-center gap-2 px-2.5 py-1.5 rounded-sm text-sm transition-colors duration-100 ${
         isActive('/profile')
-          ? 'bg-primary text-primary-foreground'
-          : 'text-muted-foreground hover:bg-primary hover:text-primary-foreground'
+          ? 'bg-primary/[0.12] text-primary font-semibold'
+          : 'text-muted-foreground hover:bg-surface-hover hover:text-foreground'
       }`}
     >
       <User className="w-4 h-4" />
-      <span className="font-light">Profile</span>
+      <span>Profile</span>
     </Link>
   );
 
@@ -151,7 +151,7 @@ export const Sidebar: React.FC = () => {
     // top bar is just brand + workspace/profile controls.
     return (
       <>
-        <div className="mobile-topbar fixed top-0 left-0 right-0 z-50 flex items-center justify-between gap-2 px-3 bg-sidebar border-b border-white/8">
+        <div className="mobile-topbar fixed top-0 left-0 right-0 z-50 flex items-center justify-between gap-2 px-3 bg-sidebar border-b border-hairline">
           <Link to="/" className="flex items-center shrink-0 min-w-0" aria-label="Home">
             <img src="/mh-logo.png" alt="materialshub" className="h-7 w-auto block dark:hidden" />
             <img src="/mh-logo-white.png" alt="" aria-hidden="true" className="h-7 w-auto hidden dark:block" />
@@ -171,11 +171,11 @@ export const Sidebar: React.FC = () => {
 
   // Desktop: horizontal top nav. Glassy so the app atmosphere reads through it.
   return (
-    <header className="sticky top-0 z-40 h-14 flex items-center px-6 bg-sidebar/70 backdrop-blur-xl border-b border-white/8">
-      <Link to="/" className="flex items-center mr-8 flex-shrink-0">
+    <header className="sticky top-0 z-40 h-12 flex items-center px-4 bg-sidebar border-b border-hairline">
+      <Link to="/" className="flex items-center mr-6 flex-shrink-0">
         {/* Logo swaps with theme: dark wordmark on light nav, white wordmark on dark nav */}
-        <img src="/mh-logo.png" alt="materialshub" className="h-8 w-auto block dark:hidden" />
-        <img src="/mh-logo-white.png" alt="" aria-hidden="true" className="h-8 w-auto hidden dark:block" />
+        <img src="/mh-logo.png" alt="materialshub" className="h-7 w-auto block dark:hidden" />
+        <img src="/mh-logo-white.png" alt="" aria-hidden="true" className="h-7 w-auto hidden dark:block" />
       </Link>
 
       {/* Scrolls horizontally when there are more nav items than fit (e.g. the
@@ -186,14 +186,14 @@ export const Sidebar: React.FC = () => {
           <Link
             key={item.id}
             to={item.path}
-            className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm whitespace-nowrap shrink-0 transition-all duration-200 ${
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-sm text-sm whitespace-nowrap shrink-0 transition-colors duration-100 ${
               isActive(item.path)
-                ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/20'
-                : 'text-muted-foreground hover:bg-primary hover:text-primary-foreground'
+                ? 'bg-primary/[0.12] text-primary font-semibold'
+                : 'text-muted-foreground hover:bg-surface-hover hover:text-foreground'
             }`}
           >
             <item.icon className="w-4 h-4 flex-shrink-0" />
-            <span className="font-light">{item.label}</span>
+            <span>{item.label}</span>
           </Link>
         ))}
         {/* App Launcher sits at the end of the nav row (after Discover), not in the

--- a/src/components/core/hub/HubDataTable.tsx
+++ b/src/components/core/hub/HubDataTable.tsx
@@ -1,0 +1,284 @@
+import React from 'react';
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Checkbox } from '@/components/core/ui/checkbox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/core/ui/table';
+
+export interface HubColumn<Row> {
+  /** Stable key — also the sort key reported to `onSortChange`. */
+  id: string;
+  header: React.ReactNode;
+  /** Cell renderer. Return a string/number and it is rendered as-is. */
+  cell: (row: Row) => React.ReactNode;
+  /** Right-align numeric columns. Money and counts ALWAYS align right. */
+  align?: 'left' | 'right';
+  sortable?: boolean;
+  /** Tailwind width class, e.g. `w-40`. Prefer leaving it off. */
+  width?: string;
+  /** Hide below the given breakpoint instead of pushing the table into scroll. */
+  hideBelow?: 'sm' | 'md' | 'lg' | 'xl';
+}
+
+export interface HubSort {
+  columnId: string;
+  direction: 'asc' | 'desc';
+}
+
+interface HubDataTableProps<Row> {
+  rows: Row[];
+  columns: HubColumn<Row>[];
+  /** Stable identity for a row — used for keys and for selection. */
+  rowId: (row: Row) => string;
+  /** Whole-row click (navigate to the record). Renders rows as pointer targets. */
+  onRowClick?: (row: Row) => void;
+
+  /** Pass BOTH to enable the selection column. */
+  selected?: Set<string>;
+  onSelectedChange?: (next: Set<string>) => void;
+
+  sort?: HubSort;
+  onSortChange?: (sort: HubSort) => void;
+
+  loading?: boolean;
+  /** Shown when `rows` is empty and not loading. */
+  empty?: React.ReactNode;
+  /** Footer band — pagination, totals, bulk actions. */
+  footer?: React.ReactNode;
+  className?: string;
+}
+
+const HIDE_BELOW = {
+  sm: 'hidden sm:table-cell',
+  md: 'hidden md:table-cell',
+  lg: 'hidden lg:table-cell',
+  xl: 'hidden xl:table-cell',
+} as const;
+
+/**
+ * DATA TABLE — the list surface: selection, sorting, loading, empty, footer.
+ *
+ * Everything here exists because a hand-rolled table in this codebase kept
+ * missing one of them:
+ *
+ *  - **The sort affordance is always visible**, greyed until used. A caret that
+ *    only appears on hover is undiscoverable on touch and invisible to anyone
+ *    scanning for "can I sort this at all".
+ *  - **Numeric columns align right and use `tabular-nums`.** Proportional digits
+ *    make a column of money impossible to compare down the page, because the
+ *    decimal points do not line up.
+ *  - **Loading renders skeleton ROWS, not a spinner.** The table keeps its shape,
+ *    so nothing below it jumps when the data lands.
+ *  - **Empty is a state, not a blank area.** A table body with nothing in it and
+ *    no message is indistinguishable from one that failed to load.
+ *  - **The header checkbox reports a partial selection** as `indeterminate`,
+ *    which is the only honest answer when some rows on the page are picked.
+ */
+export function HubDataTable<Row>({
+  rows,
+  columns,
+  rowId,
+  onRowClick,
+  selected,
+  onSelectedChange,
+  sort,
+  onSortChange,
+  loading = false,
+  empty,
+  footer,
+  className,
+}: HubDataTableProps<Row>) {
+  const selectable = !!selected && !!onSelectedChange;
+  const pageIds = React.useMemo(() => rows.map(rowId), [rows, rowId]);
+  const selectedOnPage = selected ? pageIds.filter((id) => selected.has(id)).length : 0;
+  const allOnPageSelected = selectable && rows.length > 0 && selectedOnPage === rows.length;
+  const someOnPageSelected = selectable && selectedOnPage > 0 && !allOnPageSelected;
+
+  const toggleAll = () => {
+    if (!selected || !onSelectedChange) return;
+    const next = new Set(selected);
+    if (allOnPageSelected) pageIds.forEach((id) => next.delete(id));
+    else pageIds.forEach((id) => next.add(id));
+    onSelectedChange(next);
+  };
+
+  const toggleOne = (id: string) => {
+    if (!selected || !onSelectedChange) return;
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onSelectedChange(next);
+  };
+
+  const handleSort = (col: HubColumn<Row>) => {
+    if (!col.sortable || !onSortChange) return;
+    const isCurrent = sort?.columnId === col.id;
+    onSortChange({
+      columnId: col.id,
+      direction: isCurrent && sort?.direction === 'asc' ? 'desc' : 'asc',
+    });
+  };
+
+  const colCount = columns.length + (selectable ? 1 : 0);
+
+  return (
+    <div className={cn('overflow-hidden rounded-md border border-hairline bg-card', className)}>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {selectable && (
+              <TableHead>
+                <Checkbox
+                  checked={allOnPageSelected || (someOnPageSelected ? 'indeterminate' : false)}
+                  onCheckedChange={toggleAll}
+                  aria-label={allOnPageSelected ? 'Deselect all rows' : 'Select all rows'}
+                  disabled={rows.length === 0}
+                />
+              </TableHead>
+            )}
+            {columns.map((col) => {
+              const isSorted = sort?.columnId === col.id;
+              return (
+                <TableHead
+                  key={col.id}
+                  className={cn(
+                    col.width,
+                    col.align === 'right' && 'text-right',
+                    col.hideBelow && HIDE_BELOW[col.hideBelow],
+                  )}
+                  aria-sort={
+                    isSorted ? (sort?.direction === 'asc' ? 'ascending' : 'descending') : undefined
+                  }
+                >
+                  {col.sortable && onSortChange ? (
+                    <button
+                      type="button"
+                      onClick={() => handleSort(col)}
+                      className={cn(
+                        'group inline-flex items-center gap-1 rounded-xs transition-colors hover:text-foreground',
+                        col.align === 'right' && 'flex-row-reverse',
+                        isSorted && 'text-foreground',
+                      )}
+                    >
+                      {col.header}
+                      {isSorted ? (
+                        sort?.direction === 'asc' ? (
+                          <ArrowUp className="h-3 w-3" />
+                        ) : (
+                          <ArrowDown className="h-3 w-3" />
+                        )
+                      ) : (
+                        <ChevronsUpDown className="h-3 w-3 opacity-35 group-hover:opacity-70" />
+                      )}
+                    </button>
+                  ) : (
+                    col.header
+                  )}
+                </TableHead>
+              );
+            })}
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {loading &&
+            Array.from({ length: 6 }).map((_, i) => (
+              <TableRow key={`skeleton-${i}`} className="hover:bg-transparent">
+                {selectable && (
+                  <TableCell>
+                    <div className="skeleton h-4 w-4 rounded-xs" />
+                  </TableCell>
+                )}
+                {columns.map((col) => (
+                  <TableCell key={col.id} className={cn(col.hideBelow && HIDE_BELOW[col.hideBelow])}>
+                    <div
+                      className={cn(
+                        'skeleton h-3.5 rounded-xs',
+                        col.align === 'right' ? 'ml-auto w-12' : 'w-24',
+                      )}
+                    />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+
+          {!loading && rows.length === 0 && (
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={colCount} className="py-10 text-center">
+                {empty ?? <span className="text-sm text-muted-foreground">No results.</span>}
+              </TableCell>
+            </TableRow>
+          )}
+
+          {!loading &&
+            rows.map((row) => {
+              const id = rowId(row);
+              const isSelected = !!selected?.has(id);
+              return (
+                <TableRow
+                  key={id}
+                  data-state={isSelected ? 'selected' : undefined}
+                  className={onRowClick ? 'cursor-pointer' : undefined}
+                  onClick={onRowClick ? () => onRowClick(row) : undefined}
+                >
+                  {selectable && (
+                    // Clicking the checkbox must not also fire the row's navigate.
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <Checkbox
+                        checked={isSelected}
+                        onCheckedChange={() => toggleOne(id)}
+                        aria-label={isSelected ? 'Deselect row' : 'Select row'}
+                      />
+                    </TableCell>
+                  )}
+                  {columns.map((col) => (
+                    <TableCell
+                      key={col.id}
+                      className={cn(
+                        col.align === 'right' && 'text-right tabular-nums',
+                        col.hideBelow && HIDE_BELOW[col.hideBelow],
+                      )}
+                    >
+                      {col.cell(row)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              );
+            })}
+        </TableBody>
+      </Table>
+
+      {footer && (
+        <div className="flex flex-wrap items-center gap-2 border-t border-hairline bg-surface-sunken px-3 py-2 text-xs text-muted-foreground">
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The primary cell of a row: the value you click to open the record. Rendered
+ * in the accent colour so a scan down the table shows exactly one entry point
+ * per row — which is what every list in a CRM is for.
+ */
+export const HubCellLink: React.FC<{ children: React.ReactNode; className?: string }> = ({
+  children,
+  className,
+}) => (
+  <span className={cn('font-semibold text-primary hover:underline', className)}>{children}</span>
+);
+
+/** A cell with no value. Never render an empty cell — a blank one reads as a bug. */
+export const HubCellEmpty: React.FC = () => (
+  <span className="text-muted-foreground" aria-label="No value">
+    —
+  </span>
+);

--- a/src/components/core/hub/HubEmptyState.tsx
+++ b/src/components/core/hub/HubEmptyState.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface HubEmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  /** One sentence: why it is empty, or what to do about it. */
+  description?: string;
+  /** The action that fixes it — "Create contact", "Import", "Clear filters". */
+  action?: React.ReactNode;
+  /**
+   * `filtered` renders the "your filters excluded everything" wording weight —
+   * quieter, because nothing is wrong. `empty` is a genuinely new/blank surface.
+   */
+  variant?: 'empty' | 'filtered';
+  className?: string;
+}
+
+/**
+ * EMPTY STATE.
+ *
+ * A list with no rows has to say WHICH kind of nothing it is, because the two
+ * look identical and need opposite responses:
+ *
+ *   "You have no contacts yet"       → offer the create action
+ *   "No contacts match these filters" → offer to clear the filters
+ *
+ * Showing the create action on a filtered-empty list is the classic version of
+ * this mistake: the user has 4,000 contacts and is being invited to make
+ * another one because a stage filter is set.
+ */
+export const HubEmptyState: React.FC<HubEmptyStateProps> = ({
+  icon: Icon,
+  title,
+  description,
+  action,
+  variant = 'empty',
+  className,
+}) => (
+  <div className={cn('flex flex-col items-center px-6 py-10 text-center', className)}>
+    {Icon && (
+      <div
+        className={cn(
+          'mb-3 flex h-10 w-10 items-center justify-center rounded-md',
+          variant === 'filtered' ? 'bg-surface-sunken' : 'bg-primary/10',
+        )}
+      >
+        <Icon
+          className={cn(
+            'h-5 w-5',
+            variant === 'filtered' ? 'text-muted-foreground' : 'text-primary',
+          )}
+          aria-hidden="true"
+        />
+      </div>
+    )}
+    <p className="font-sans text-sm font-semibold text-foreground">{title}</p>
+    {description && (
+      <p className="mt-1 max-w-sm text-xs text-muted-foreground">{description}</p>
+    )}
+    {action && <div className="mt-3 flex flex-wrap items-center justify-center gap-2">{action}</div>}
+  </div>
+);

--- a/src/components/core/hub/HubRecordLayout.tsx
+++ b/src/components/core/hub/HubRecordLayout.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { ChevronDown, Plus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/core/ui/avatar';
+
+interface HubRecordLayoutProps {
+  /** Left rail: identity card + property panels. ~300px, scrolls with the page. */
+  left: React.ReactNode;
+  /** Centre column: the activity/timeline/tabs. Takes all remaining width. */
+  children: React.ReactNode;
+  /** Right rail: associated records. Omit for a two-column record. */
+  right?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * RECORD LAYOUT — the three-column shell for a single record (contact, company,
+ * deal, order, property).
+ *
+ * The columns are not decoration; each answers a different question, and mixing
+ * them is what turns a record page into a wall:
+ *
+ *   left    WHO/WHAT is this        — identity + stored fields
+ *   centre  WHAT HAPPENED           — activity, notes, emails, tasks
+ *   right   WHAT IS IT CONNECTED TO — deals, tickets, companies, files
+ *
+ * The rails are fixed-width and the centre is fluid, because the rails hold
+ * label/value pairs (which have a natural width and look broken stretched) while
+ * the centre holds prose and lists (which want the room). Below `lg` the whole
+ * thing stacks in that same order — identity, then activity, then associations —
+ * which is also the order of decreasing usefulness on a phone.
+ */
+export const HubRecordLayout: React.FC<HubRecordLayoutProps> = ({
+  left,
+  children,
+  right,
+  className,
+}) => (
+  <div
+    className={cn(
+      'flex flex-col gap-4 p-4 lg:flex-row lg:items-start',
+      className,
+    )}
+  >
+    <aside className="w-full shrink-0 space-y-3 lg:w-[300px] xl:w-[320px]">{left}</aside>
+
+    {/* min-w-0 is load-bearing: without it a wide table or a long unbroken token
+        in the centre column sets the flex basis and shoves the right rail off
+        the viewport instead of scrolling inside its own container. */}
+    <div className="min-w-0 flex-1 space-y-3">{children}</div>
+
+    {right && <aside className="w-full shrink-0 space-y-3 lg:w-[300px] xl:w-[320px]">{right}</aside>}
+  </div>
+);
+
+interface HubRecordIdentityProps {
+  name: string;
+  subtitle?: string;
+  avatarUrl?: string | null;
+  /** Falls back to initials derived from `name`. */
+  initials?: string;
+  /** Quick actions under the name (note, email, call, task…). */
+  actions?: React.ReactNode;
+  /** Badges/tags under the subtitle (lifecycle stage, owner, type). */
+  meta?: React.ReactNode;
+}
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/**
+ * The identity card at the top of the left rail: avatar, name, role, actions.
+ * Centred rather than left-aligned — this is the one block on the page whose
+ * job is "you are looking at THIS record", and centring it stops it reading as
+ * just another property row in the panel below.
+ */
+export const HubRecordIdentity: React.FC<HubRecordIdentityProps> = ({
+  name,
+  subtitle,
+  avatarUrl,
+  initials,
+  actions,
+  meta,
+}) => (
+  <div className="rounded-md border border-hairline bg-card p-4 text-center">
+    <Avatar className="mx-auto h-16 w-16">
+      {avatarUrl && <AvatarImage src={avatarUrl} alt="" />}
+      <AvatarFallback className="bg-primary/10 text-lg font-semibold text-primary">
+        {initials ?? initialsOf(name)}
+      </AvatarFallback>
+    </Avatar>
+
+    <h2 className="mt-2.5 break-words font-sans text-base font-semibold leading-tight text-foreground">
+      {name}
+    </h2>
+    {subtitle && <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>}
+
+    {meta && <div className="mt-2 flex flex-wrap items-center justify-center gap-1">{meta}</div>}
+
+    {actions && (
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-1.5">{actions}</div>
+    )}
+  </div>
+);
+
+interface HubPanelProps {
+  title: React.ReactNode;
+  /** Rendered right of the title — a count, an "+ Add", a link out. */
+  action?: React.ReactNode;
+  /** Start collapsed. Only meaningful when `collapsible`. */
+  defaultOpen?: boolean;
+  collapsible?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * A rail panel: small header, hairline, body. `collapsible` turns the header
+ * into a disclosure button.
+ *
+ * A record page routinely carries 8–12 of these. That is exactly why the header
+ * is 12px semibold and not a card title — twelve 16px headings down a 300px rail
+ * is a table of contents, not a record.
+ */
+export const HubPanel: React.FC<HubPanelProps> = ({
+  title,
+  action,
+  defaultOpen = true,
+  collapsible = false,
+  children,
+  className,
+}) => {
+  const [open, setOpen] = React.useState(defaultOpen);
+  const body = <div className="p-3">{children}</div>;
+
+  return (
+    <section className={cn('overflow-hidden rounded-md border border-hairline bg-card', className)}>
+      <div className="flex items-center justify-between gap-2 border-b border-hairline px-3 py-2">
+        {collapsible ? (
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            className="flex min-w-0 items-center gap-1.5 text-xs font-semibold text-foreground transition-colors hover:text-primary"
+          >
+            <ChevronDown
+              className={cn('h-3.5 w-3.5 shrink-0 transition-transform', !open && '-rotate-90')}
+              aria-hidden="true"
+            />
+            <span className="truncate">{title}</span>
+          </button>
+        ) : (
+          <h3 className="truncate font-sans text-xs font-semibold text-foreground">{title}</h3>
+        )}
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+      {(!collapsible || open) && body}
+    </section>
+  );
+};
+
+/** "+ Add deal" — the standard rail-panel action. */
+export const HubPanelAddAction: React.FC<{ label: string; onClick?: () => void }> = ({
+  label,
+  onClick,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="inline-flex items-center gap-0.5 rounded-xs text-xs font-semibold text-primary hover:underline"
+  >
+    <Plus className="h-3 w-3" aria-hidden="true" />
+    {label}
+  </button>
+);
+
+interface HubPropertyProps {
+  label: string;
+  children: React.ReactNode;
+  /** Stack label above value (the default) or put them side by side. */
+  layout?: 'stacked' | 'inline';
+}
+
+/**
+ * One stored field: label + value.
+ *
+ * Stacked by default. A side-by-side label/value pair inside a 300px rail
+ * leaves ~140px for the value, so every email address, address line and company
+ * name truncates — and a truncated value in a properties panel is worse than no
+ * panel, because it looks like the data is short rather than clipped.
+ *
+ * An absent value renders an em dash, never an empty line: "we have no phone
+ * number" and "this row failed to render" must not look the same.
+ */
+export const HubProperty: React.FC<HubPropertyProps> = ({ label, children, layout = 'stacked' }) => {
+  const empty = children === null || children === undefined || children === '';
+  const value = empty ? <span className="text-muted-foreground">—</span> : children;
+
+  if (layout === 'inline') {
+    return (
+      <div className="flex items-baseline justify-between gap-3 py-1">
+        <dt className="shrink-0 text-xs text-muted-foreground">{label}</dt>
+        <dd className="min-w-0 break-words text-right text-sm text-foreground">{value}</dd>
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-1.5">
+      <dt className="text-[11px] font-semibold text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5 break-words text-sm text-foreground">{value}</dd>
+    </div>
+  );
+};
+
+/** Wrapper for a run of <HubProperty> — supplies the <dl> and row rhythm. */
+export const HubPropertyList: React.FC<{ children: React.ReactNode; className?: string }> = ({
+  children,
+  className,
+}) => <dl className={cn('divide-y divide-hairline', className)}>{children}</dl>;

--- a/src/components/core/hub/HubSideNav.tsx
+++ b/src/components/core/hub/HubSideNav.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import type { LucideIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export interface HubNavItem {
+  id: string;
+  label: string;
+  /** Route for a link item. Omit and pass `onSelect` for a controlled pane. */
+  to?: string;
+  icon?: LucideIcon;
+  /** Right-aligned count. `0` renders nothing — an empty count is noise. */
+  count?: number;
+  children?: HubNavItem[];
+}
+
+export interface HubNavGroup {
+  /** Group heading. Omit for an ungrouped run of items. */
+  label?: string;
+  items: HubNavItem[];
+}
+
+interface HubSideNavProps {
+  groups: HubNavGroup[];
+  /** Controlled mode: the active item id. Ignored for items that carry `to`. */
+  activeId?: string;
+  onSelect?: (id: string) => void;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * SIDE NAV — the settings/section rail (Settings, Finance sections, Admin).
+ *
+ * Three decisions worth keeping:
+ *
+ *  - **The active row is a tinted row with a leading accent bar**, not a filled
+ *    pill. A rail of 20 rows with a saturated pill on one of them is a rail with
+ *    a button in it; the bar marks position without competing with the page's
+ *    actual primary action.
+ *  - **Groups have headings, and headings are not clickable.** A nav where some
+ *    parents navigate and some only expand teaches nothing about which is which.
+ *    A parent with children is a disclosure; a leaf is a link.
+ *  - **It scrolls independently** (`sticky` + own overflow), so a long section
+ *    list does not drag the page's scroll position around.
+ */
+export const HubSideNav: React.FC<HubSideNavProps> = ({
+  groups,
+  activeId,
+  onSelect,
+  className,
+  'aria-label': ariaLabel = 'Section navigation',
+}) => (
+  <nav
+    aria-label={ariaLabel}
+    className={cn(
+      'scroll-y-clean w-full shrink-0 border-hairline lg:sticky lg:top-0 lg:max-h-[calc(100dvh-3rem)] lg:w-56 lg:border-r lg:pr-2',
+      className,
+    )}
+  >
+    {groups.map((group, gi) => (
+      <div key={group.label ?? `group-${gi}`} className={gi > 0 ? 'mt-4' : undefined}>
+        {group.label && (
+          <h3 className="px-3 pb-1 font-sans text-[11px] font-semibold text-muted-foreground">
+            {group.label}
+          </h3>
+        )}
+        <ul className="space-y-0.5">
+          {group.items.map((item) => (
+            <HubSideNavRow key={item.id} item={item} activeId={activeId} onSelect={onSelect} />
+          ))}
+        </ul>
+      </div>
+    ))}
+  </nav>
+);
+
+const HubSideNavRow: React.FC<{
+  item: HubNavItem;
+  activeId?: string;
+  onSelect?: (id: string) => void;
+  depth?: number;
+}> = ({ item, activeId, onSelect, depth = 0 }) => {
+  const Icon = item.icon;
+  const hasChildren = !!item.children?.length;
+  const isActive = activeId === item.id;
+
+  const inner = (
+    <>
+      {Icon && <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />}
+      <span className="min-w-0 flex-1 truncate">{item.label}</span>
+      {!!item.count && (
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{item.count}</span>
+      )}
+    </>
+  );
+
+  const rowClass = (active: boolean) =>
+    cn('sidebar-item w-full text-left', active && 'active', depth > 0 && 'pl-8');
+
+  return (
+    <li>
+      {item.to ? (
+        <NavLink to={item.to} className={({ isActive: navActive }) => rowClass(navActive)} end>
+          {inner}
+        </NavLink>
+      ) : (
+        <button type="button" onClick={() => onSelect?.(item.id)} className={rowClass(isActive)}>
+          {inner}
+        </button>
+      )}
+
+      {hasChildren && (
+        <ul className="mt-0.5 space-y-0.5">
+          {item.children?.map((child) => (
+            <HubSideNavRow
+              key={child.id}
+              item={child}
+              activeId={activeId}
+              onSelect={onSelect}
+              depth={depth + 1}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+};

--- a/src/components/core/hub/HubStatTile.tsx
+++ b/src/components/core/hub/HubStatTile.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { ArrowDown, ArrowUp, Info, Minus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/core/ui/tooltip';
+
+export interface HubStatDelta {
+  /** Already-formatted, e.g. "43.75%" or "+1.2k". This does not format numbers. */
+  value: string;
+  direction: 'up' | 'down' | 'flat';
+  /**
+   * Whether `up` is good. Defaults to true. Set false for cost, churn, latency —
+   * a rising bounce rate is not a green arrow, and colouring by DIRECTION alone
+   * is how a dashboard ends up congratulating you on your error rate.
+   */
+  upIsGood?: boolean;
+  /** Period the delta is measured against, e.g. "vs last month". */
+  caption?: string;
+}
+
+interface HubStatTileProps {
+  label: string;
+  /** The number. Pre-formatted (currency, unit, thousands separators). */
+  value: React.ReactNode;
+  /** Small qualifier under the label — "OFFLINE SOURCE", "LEAD", "VIEWS". */
+  category?: string;
+  delta?: HubStatDelta;
+  /** Explains how the metric is derived. Rendered as an info tooltip. */
+  help?: string;
+  /** Sparkline / mini chart slot, rendered below the number. */
+  chart?: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+}
+
+/**
+ * KPI TILE — one number, its label, and how it moved.
+ *
+ * Rules this encodes, all of which a hand-rolled tile tends to get wrong:
+ *
+ *  - **The number is the loudest thing.** 24px semibold with `tabular-nums`, so
+ *    a row of tiles has its digits on a shared grid and the eye can compare
+ *    magnitudes without reading each one.
+ *  - **The delta is coloured by MEANING, not direction** (see `upIsGood`), and
+ *    carries an arrow as well as a colour, because roughly 1 in 12 men cannot
+ *    separate the red from the green.
+ *  - **The label sits above the number.** Below, it reads as a caption for
+ *    whatever comes next in the column rather than a name for the figure.
+ */
+export const HubStatTile: React.FC<HubStatTileProps> = ({
+  label,
+  value,
+  category,
+  delta,
+  help,
+  chart,
+  onClick,
+  className,
+}) => {
+  const good = delta ? (delta.upIsGood ?? true) === (delta.direction === 'up') : false;
+  const DeltaIcon = delta?.direction === 'up' ? ArrowUp : delta?.direction === 'down' ? ArrowDown : Minus;
+
+  const body = (
+    <>
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-xs font-semibold text-muted-foreground">{label}</p>
+        {help && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={`About ${label}`}
+                className="shrink-0 rounded-xs text-muted-foreground hover:text-foreground"
+              >
+                <Info className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{help}</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+
+      {category && (
+        <p className="mt-1 text-[10px] font-semibold tracking-wide text-muted-foreground">
+          {category}
+        </p>
+      )}
+
+      <p className="mt-1 text-2xl font-semibold tabular-nums leading-none tracking-tight text-foreground">
+        {value}
+      </p>
+
+      {delta && (
+        <p
+          className={cn(
+            'mt-1.5 flex items-center gap-1 text-xs font-semibold tabular-nums',
+            delta.direction === 'flat'
+              ? 'text-muted-foreground'
+              : good
+                ? 'text-[hsl(var(--success))]'
+                : 'text-[hsl(var(--error))]',
+          )}
+        >
+          <DeltaIcon className="h-3 w-3" aria-hidden="true" />
+          {delta.value}
+          {delta.caption && (
+            <span className="font-normal text-muted-foreground">{delta.caption}</span>
+          )}
+        </p>
+      )}
+
+      {chart && <div className="mt-2.5">{chart}</div>}
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'panel-interactive rounded-md border border-hairline bg-card p-3.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          className,
+        )}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return (
+    <div className={cn('rounded-md border border-hairline bg-card p-3.5', className)}>{body}</div>
+  );
+};
+
+/**
+ * The dashboard grid. Auto-fits tiles at a ~220px minimum rather than pinning a
+ * column count per breakpoint: a report page can hold 3 tiles or 11, and a fixed
+ * `lg:grid-cols-4` leaves an orphan on its own row for every count that is not a
+ * multiple of four.
+ */
+export const HubStatGrid: React.FC<{ children: React.ReactNode; className?: string }> = ({
+  children,
+  className,
+}) => (
+  <div
+    className={cn('grid gap-3', className)}
+    style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}
+  >
+    {children}
+  </div>
+);

--- a/src/components/core/hub/HubTabNav.tsx
+++ b/src/components/core/hub/HubTabNav.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Link, useMatch, useResolvedPath } from 'react-router-dom';
+import { Plus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export interface HubTabItem {
+  id: string;
+  label: string;
+  /** Route for a link tab. Omit and pass `onSelect` for a controlled tab. */
+  to?: string;
+  /** Right-hand count. `0` renders nothing — an empty count is noise. */
+  count?: number;
+  /** Marks a saved/pinned view (a dot before the label). */
+  pinned?: boolean;
+  /** Match the route as a prefix rather than exactly (a section with children). */
+  matchPrefix?: boolean;
+}
+
+interface HubTabNavProps {
+  items: HubTabItem[];
+  /** Controlled mode: the active tab id. Ignored for items that carry `to`. */
+  activeId?: string;
+  onSelect?: (id: string) => void;
+  /** Trailing action rendered after the last tab — "+ Add view", "All views". */
+  trailing?: React.ReactNode;
+  className?: string;
+  'aria-label'?: string;
+}
+
+// Shared box for both the link and the button form. Colour, weight and the
+// active underline all come from the platform's `[role="tab"]` rules in
+// index.css, so a route tab and an in-page tab are indistinguishable on screen.
+const TAB_CLASS =
+  'relative inline-flex min-h-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 md:min-h-0';
+
+const TabBody: React.FC<{ item: HubTabItem }> = ({ item }) => (
+  <>
+    {item.pinned && (
+      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-label="Saved view" />
+    )}
+    {item.label}
+    {!!item.count && <span className="tabular-nums opacity-70">{item.count}</span>}
+  </>
+);
+
+/**
+ * A route tab. A real <a>, not a button that calls `navigate()` — middle-click,
+ * ⌘-click and "copy link address" are how people actually use a tab strip in a
+ * CRM, and all three disappear the moment navigation is a click handler.
+ *
+ * `data-state` is resolved here rather than through NavLink's className
+ * render-prop because the platform's tab CSS keys off the attribute, and a
+ * render-prop can only produce a class.
+ */
+const HubTabLink: React.FC<{ item: HubTabItem }> = ({ item }) => {
+  const resolved = useResolvedPath(item.to ?? '');
+  const match = useMatch({ path: resolved.pathname, end: !item.matchPrefix });
+  const active = !!match;
+
+  return (
+    <Link
+      to={item.to ?? ''}
+      role="tab"
+      aria-selected={active}
+      data-state={active ? 'active' : 'inactive'}
+      className={TAB_CLASS}
+    >
+      <TabBody item={item} />
+    </Link>
+  );
+};
+
+/**
+ * TAB NAV — the underline strip used for page sections and saved views.
+ *
+ * `role="tablist"` + `role="tab"` so the shared CSS picks it up, but in link
+ * mode it deliberately omits `aria-controls`/`tabpanel` wiring: there is no
+ * panel in this document to control — activating a tab loads a route.
+ */
+export const HubTabNav: React.FC<HubTabNavProps> = ({
+  items,
+  activeId,
+  onSelect,
+  trailing,
+  className,
+  'aria-label': ariaLabel = 'Sections',
+}) => (
+  <div
+    role="tablist"
+    aria-label={ariaLabel}
+    aria-orientation="horizontal"
+    className={cn(
+      'flex w-full items-center gap-1 overflow-x-auto border-b border-hairline [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+      className,
+    )}
+  >
+    {items.map((item) =>
+      item.to ? (
+        <HubTabLink key={item.id} item={item} />
+      ) : (
+        <button
+          key={item.id}
+          type="button"
+          role="tab"
+          aria-selected={activeId === item.id}
+          data-state={activeId === item.id ? 'active' : 'inactive'}
+          onClick={() => onSelect?.(item.id)}
+          className={TAB_CLASS}
+        >
+          <TabBody item={item} />
+        </button>
+      ),
+    )}
+
+    {trailing && <div className="ml-2 flex shrink-0 items-center gap-2 pl-1">{trailing}</div>}
+  </div>
+);
+
+/** "+ Add view" — the standard trailing action on a saved-views strip. */
+export const HubTabAddAction: React.FC<{ label: string; onClick?: () => void }> = ({
+  label,
+  onClick,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="inline-flex items-center gap-0.5 rounded-xs px-1 text-xs font-semibold text-primary hover:underline"
+  >
+    <Plus className="h-3 w-3" aria-hidden="true" />
+    {label}
+  </button>
+);

--- a/src/components/core/hub/HubTimeline.tsx
+++ b/src/components/core/hub/HubTimeline.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { ChevronRight, Pin } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface HubTimelineProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * ACTIVITY TIMELINE — the centre column of a record page.
+ *
+ * Grouped, not endless. Entries arrive under a `HubTimelineGroup` heading
+ * ("Pinned", "Upcoming", "March 2020") because an undifferentiated reverse-chron
+ * list of 200 events answers "what happened here" with "everything, equally".
+ * The group heading is the only thing that makes the feed skimmable.
+ */
+export const HubTimeline: React.FC<HubTimelineProps> = ({ children, className }) => (
+  <div className={cn('space-y-4', className)}>{children}</div>
+);
+
+/** A dated / named section of the feed. */
+export const HubTimelineGroup: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <section>
+    <h4 className="mb-1.5 font-sans text-[11px] font-semibold text-muted-foreground">{label}</h4>
+    <div className="space-y-1.5">{children}</div>
+  </section>
+);
+
+interface HubTimelineItemProps {
+  icon?: LucideIcon;
+  /** The bolded lead — "Task assigned to Anna Kutch", "Note from Nick". */
+  title: React.ReactNode;
+  /** Right-aligned timestamp. Already-formatted text; this does not format dates. */
+  timestamp?: string;
+  /** Flags the timestamp as overdue (red) rather than neutral. */
+  overdue?: boolean;
+  pinned?: boolean;
+  /** Body — the note text, the email preview, the meeting agenda. */
+  children?: React.ReactNode;
+  /** Renders the item as an expandable disclosure. */
+  expandable?: boolean;
+  defaultExpanded?: boolean;
+  className?: string;
+}
+
+/**
+ * One event in the feed.
+ *
+ * The timestamp is right-aligned on the title row and the body is indented under
+ * it, so a column of times reads down the right edge and a column of subjects
+ * reads down the left. Both are scannable at once; interleaving them into one
+ * text run makes neither so.
+ */
+export const HubTimelineItem: React.FC<HubTimelineItemProps> = ({
+  icon: Icon,
+  title,
+  timestamp,
+  overdue = false,
+  pinned = false,
+  children,
+  expandable = false,
+  defaultExpanded = false,
+  className,
+}) => {
+  const [expanded, setExpanded] = React.useState(defaultExpanded);
+  const showBody = !!children && (!expandable || expanded);
+
+  const titleRow = (
+    <div className="flex w-full items-start gap-2">
+      {expandable && (
+        <ChevronRight
+          className={cn(
+            'mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+            expanded && 'rotate-90',
+          )}
+          aria-hidden="true"
+        />
+      )}
+      {Icon && !expandable && (
+        <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      )}
+      {/* The pin sits IN the title row, not absolutely in the corner: the corner
+          is where the timestamp lives, and an absolute badge landed on top of it
+          on every pinned item that had a date — which is all of them. */}
+      {pinned && <Pin className="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary" aria-label="Pinned" />}
+      <span className="min-w-0 flex-1 text-left text-sm text-foreground">{title}</span>
+      {timestamp && (
+        <span
+          className={cn(
+            'shrink-0 whitespace-nowrap text-xs tabular-nums',
+            overdue ? 'font-semibold text-destructive' : 'text-muted-foreground',
+          )}
+        >
+          {timestamp}
+        </span>
+      )}
+    </div>
+  );
+
+  return (
+    <article
+      className={cn(
+        'relative rounded-md border border-hairline bg-card px-3 py-2.5',
+        pinned && 'border-l-2 border-l-primary',
+        className,
+      )}
+    >
+      {expandable ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="w-full rounded-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {titleRow}
+        </button>
+      ) : (
+        titleRow
+      )}
+
+      {showBody && (
+        <div className={cn('mt-1.5 text-sm text-muted-foreground', (expandable || Icon) && 'pl-[1.375rem]')}>
+          {children}
+        </div>
+      )}
+    </article>
+  );
+};

--- a/src/components/core/hub/HubToolbar.tsx
+++ b/src/components/core/hub/HubToolbar.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { Search, X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Input } from '@/components/core/ui/input';
+import { Button } from '@/components/core/ui/button';
+
+interface HubToolbarProps {
+  /** Controlled search text. Omit both search props to hide the field. */
+  search?: string;
+  onSearchChange?: (value: string) => void;
+  searchPlaceholder?: string;
+  /** Filter controls — usually a row of <HubFilterSelect>. */
+  filters?: React.ReactNode;
+  /** Right-aligned actions (Export, Save view, column picker…). */
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * TOOLBAR — the band directly above a list: search, filters, view actions.
+ *
+ * It is a sunken strip, not another panel. That matters: a list screen has a
+ * page header, a toolbar and a table, and if all three are cards you get three
+ * stacked white boxes with two gutters of dead space between them. Sinking the
+ * toolbar and letting it sit flush on top of the table makes the two read as
+ * one object — the list and its controls.
+ *
+ * Filters are LEFT-aligned next to search because they narrow the same result
+ * set; actions are right-aligned because they act on it. That split is the
+ * whole reason the row is legible without labels.
+ */
+export const HubToolbar: React.FC<HubToolbarProps> = ({
+  search,
+  onSearchChange,
+  searchPlaceholder = 'Search',
+  filters,
+  actions,
+  className,
+}) => {
+  const showSearch = onSearchChange !== undefined;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-center gap-2 border-b border-hairline bg-surface-sunken px-3 py-2',
+        className,
+      )}
+    >
+      {showSearch && (
+        <div className="relative min-w-[180px] flex-1 sm:max-w-xs">
+          <Search
+            className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            value={search ?? ''}
+            onChange={(e) => onSearchChange?.(e.target.value)}
+            placeholder={searchPlaceholder}
+            aria-label={searchPlaceholder}
+            className="h-8 pl-8 pr-8"
+          />
+          {!!search && (
+            <button
+              type="button"
+              onClick={() => onSearchChange?.('')}
+              aria-label="Clear search"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-xs p-0.5 text-muted-foreground hover:bg-surface-hover hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {filters && <div className="flex flex-wrap items-center gap-1.5">{filters}</div>}
+
+      {actions && <div className="ml-auto flex flex-wrap items-center gap-1.5">{actions}</div>}
+    </div>
+  );
+};
+
+export interface HubFilterOption {
+  value: string;
+  label: string;
+}
+
+interface HubFilterSelectProps {
+  label: string;
+  value: string;
+  options: HubFilterOption[];
+  onChange: (value: string) => void;
+  /** Value that means "no filter". Defaults to `'all'`. */
+  allValue?: string;
+  className?: string;
+}
+
+/**
+ * FILTER CHIP — a compact native <select> dressed as a toolbar control.
+ *
+ * Native rather than a Radix Select on purpose: a filter row can hold six of
+ * these, each with a few hundred options (owners, stages, categories), and the
+ * native control gets keyboard type-ahead, mobile's own picker and zero popup
+ * layout cost for free.
+ *
+ * When a filter is ACTIVE the chip switches to the accent — border, text and a
+ * faint fill. Without that, a list showing 3 of 400 rows looks like a list with
+ * 3 rows, and "why is this empty" is the single most common support question a
+ * filtered table generates.
+ */
+export const HubFilterSelect: React.FC<HubFilterSelectProps> = ({
+  label,
+  value,
+  options,
+  onChange,
+  allValue = 'all',
+  className,
+}) => {
+  const active = value !== allValue;
+  const selected = options.find((o) => o.value === value);
+
+  return (
+    <label
+      className={cn(
+        'relative inline-flex h-8 items-center rounded-sm border pl-2.5 pr-6 text-xs transition-colors',
+        active
+          ? 'border-primary bg-primary/[0.08] text-primary font-semibold'
+          : 'border-hairline bg-card text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground',
+        className,
+      )}
+    >
+      <span className="sr-only">{label}</span>
+      <span aria-hidden="true" className="whitespace-nowrap">
+        {active ? (selected?.label ?? value) : label}
+      </span>
+      {/* The real control is stretched invisibly over the chip so the whole chip
+          is the hit target and the browser still owns the popup. */}
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={label}
+        className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 12 12"
+        className="pointer-events-none absolute right-2 h-3 w-3 opacity-70"
+      >
+        <path d="M2.5 4.5 6 8l3.5-3.5" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    </label>
+  );
+};
+
+interface HubResetFiltersProps {
+  count: number;
+  onReset: () => void;
+}
+
+/** "3 filters · Clear" — only rendered when something is actually filtering. */
+export const HubResetFilters: React.FC<HubResetFiltersProps> = ({ count, onReset }) =>
+  count > 0 ? (
+    <Button variant="link" size="sm" onClick={onReset} className="h-8 text-xs">
+      Clear {count} filter{count === 1 ? '' : 's'}
+    </Button>
+  ) : null;

--- a/src/components/core/hub/index.ts
+++ b/src/components/core/hub/index.ts
@@ -1,0 +1,41 @@
+/**
+ * HUB — the application-shell pattern library.
+ *
+ * `components/core/ui/*` holds the PRIMITIVES (a button, a table cell, a
+ * checkbox). This folder holds the PATTERNS those primitives compose into: a
+ * list screen, a record screen, a dashboard, a settings rail. The split matters
+ * because the patterns are where the design decisions live — a `<Table>` cannot
+ * know that money aligns right, that a filtered-empty list must not offer a
+ * create button, or that a record page has three columns with three different
+ * jobs. Those rules live here, once, instead of being re-derived per page.
+ *
+ * See `.claude/design-system.md` for the rules and `/design-system` (in-app)
+ * for the live specimen sheet.
+ */
+export { HubToolbar, HubFilterSelect, HubResetFilters } from './HubToolbar';
+export type { HubFilterOption } from './HubToolbar';
+
+export { HubDataTable, HubCellLink, HubCellEmpty } from './HubDataTable';
+export type { HubColumn, HubSort } from './HubDataTable';
+
+export {
+  HubRecordLayout,
+  HubRecordIdentity,
+  HubPanel,
+  HubPanelAddAction,
+  HubProperty,
+  HubPropertyList,
+} from './HubRecordLayout';
+
+export { HubTimeline, HubTimelineGroup, HubTimelineItem } from './HubTimeline';
+
+export { HubStatTile, HubStatGrid } from './HubStatTile';
+export type { HubStatDelta } from './HubStatTile';
+
+export { HubSideNav } from './HubSideNav';
+export type { HubNavItem, HubNavGroup } from './HubSideNav';
+
+export { HubTabNav, HubTabAddAction } from './HubTabNav';
+export type { HubTabItem } from './HubTabNav';
+
+export { HubEmptyState } from './HubEmptyState';

--- a/src/components/core/ui/alert-dialog.tsx
+++ b/src/components/core/ui/alert-dialog.tsx
@@ -38,7 +38,7 @@ const AlertDialogContent = React.forwardRef<
         // track horizontally, max-h + overflow-y-auto keep a tall centred
         // dialog inside the viewport (top/buttons reachable), and the
         // calc width restores side gutters on mobile.
-        'fixed left-[50%] top-[50%] z-50 grid grid-cols-1 w-[calc(100%-2rem)] sm:w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid grid-cols-1 w-[calc(100%-2rem)] sm:w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border border-hairline bg-card p-6 shadow-overlay duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-2xl',
         className,
       )}
       {...props}

--- a/src/components/core/ui/badge.tsx
+++ b/src/components/core/ui/badge.tsx
@@ -3,34 +3,52 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * TAG — a squared, low-saturation label. Not a pill, and not a solid block of
+ * brand colour.
+ *
+ * Two rules this encodes:
+ *
+ *  - **Shape separates label from action.** Buttons are squared with a 4px
+ *    radius; a tag is squared with 2px. When both were pills, a toolbar of
+ *    chips and buttons had no readable grammar.
+ *  - **A status is tinted, not filled.** A saturated fill has the visual weight
+ *    of a primary button, so a table with a status column read as a table with
+ *    a button in every row. Semantic variants are a pale tint + a deep text
+ *    colour + a matching hairline, which is legible at 11px and still lets the
+ *    row's own text stay the loudest thing in the row.
+ *
+ * `default` (solid accent) survives for the one case that wants weight: a count
+ * badge on a nav item.
+ */
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center gap-1 rounded-xs border px-1.5 py-0.5 text-xs font-semibold leading-4 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1',
   {
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm border-none',
+          'border-transparent bg-primary text-primary-foreground',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/90 shadow-sm border-none',
+          'border-hairline bg-surface-sunken text-foreground',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-sm border-none',
-        outline: 'text-foreground hover:bg-accent shadow-sm border-none',
+          'border-transparent bg-destructive text-destructive-foreground',
+        outline: 'border-hairline bg-transparent text-foreground',
         success:
-          'badge-success border-none',
+          'border-[hsl(var(--success)/0.25)] bg-[hsl(var(--success-bg))] text-[hsl(var(--success))]',
         warning:
-          'badge-warning border-none',
+          'border-[hsl(var(--warning)/0.25)] bg-[hsl(var(--warning-bg))] text-[hsl(var(--warning))]',
         error:
-          'badge-error border-none',
+          'border-[hsl(var(--error)/0.25)] bg-[hsl(var(--error-bg))] text-[hsl(var(--error))]',
         info:
-          'badge-info border-transparent',
+          'border-[hsl(var(--info)/0.25)] bg-[hsl(var(--info-bg))] text-[hsl(var(--info))]',
         high:
-          'border-transparent bg-[hsl(var(--badge-high))] text-[hsl(var(--badge-high-fg))]',
+          'border-[hsl(var(--error)/0.25)] bg-[hsl(var(--error-bg))] text-[hsl(var(--error))]',
         medium:
-          'border-transparent bg-[hsl(var(--badge-medium))] text-[hsl(var(--badge-medium-fg))]',
+          'border-[hsl(var(--warning)/0.25)] bg-[hsl(var(--warning-bg))] text-[hsl(var(--warning))]',
         low:
-          'border-transparent bg-[hsl(var(--badge-low))] text-[hsl(var(--badge-low-fg))]',
+          'border-hairline bg-surface-sunken text-muted-foreground',
         neutral:
-          'badge-neutral border-transparent',
+          'border-hairline bg-surface-sunken text-muted-foreground',
       },
     },
     defaultVariants: {

--- a/src/components/core/ui/button.tsx
+++ b/src/components/core/ui/button.tsx
@@ -4,26 +4,55 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * BUTTON — rectangular, 4px radius, flat fill, no lift.
+ *
+ * The previous button was a fully-rounded pill that rose 2px and grew its
+ * shadow on hover. Two problems, in order of how much they cost:
+ *
+ *  1. A pill is the same silhouette as a status chip, a filter chip and an
+ *     active tab — all of which this platform also rendered as pills. In a
+ *     toolbar you could not tell an action from a label without reading it.
+ *     Squaring the action and squaring the tag differently is what makes a
+ *     toolbar scannable.
+ *  2. `hover:-translate-y-0.5` moves the target out from under the pointer,
+ *     and in a row of buttons it shoves the row.
+ *
+ * Hierarchy is carried by FILL, not by size: `default` (solid accent) is the
+ * one primary action on a screen; `secondary` (accent outline) is its partner;
+ * `outline` (neutral hairline) is everything else; `ghost` is icon/table-row
+ * chrome. If a screen has two solid buttons, one of them is wrong.
+ */
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-sm text-sm font-semibold ring-offset-background transition-colors duration-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:opacity-90 rounded-full shadow-sm hover:shadow-md hover:-translate-y-0.5',
+        default:
+          'bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90 rounded-full shadow-sm hover:shadow-md',
-        outline:
-          'bg-white/8 text-foreground border border-white/12 hover:bg-white/12 hover:border-white/20 rounded-full',
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90 active:bg-destructive/80',
+        // Accent outline — the canonical "second action" next to a primary.
         secondary:
-          'bg-white/6 text-foreground border border-white/10 hover:bg-white/10 rounded-full',
-        ghost: 'hover:bg-white/8 hover:text-foreground rounded-lg',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'bg-transparent text-primary border border-primary hover:bg-primary/[0.08] active:bg-primary/[0.14]',
+        // Neutral outline — tertiary actions, toolbars, filter triggers.
+        outline:
+          'bg-card text-foreground border border-hairline hover:bg-surface-hover hover:border-muted-foreground/50',
+        ghost:
+          'bg-transparent text-muted-foreground hover:bg-surface-hover hover:text-foreground',
+        link: 'text-primary underline-offset-2 hover:underline p-0 h-auto',
       },
       size: {
-        default: 'h-11 px-6 py-2.5',
-        sm: 'h-9 rounded-full px-4',
-        lg: 'h-12 rounded-full px-8 text-base',
-        icon: 'h-10 w-10 rounded-full',
+        // 36px default. The old default was 44px, which is a touch target
+        // standing in for a desktop control: it set the height of every table
+        // row that carried an action and every toolbar it appeared in. 36px is
+        // dense enough for a data UI and still comfortably tappable; `sm` (32px)
+        // is for inside a table row, `lg` (40px) for a page's single hero CTA.
+        default: 'h-9 px-3.5',
+        sm: 'h-8 px-2.5 text-xs',
+        lg: 'h-10 px-5',
+        icon: 'h-9 w-9 p-0',
+        'icon-sm': 'h-8 w-8 p-0',
       },
     },
     defaultVariants: {

--- a/src/components/core/ui/card.tsx
+++ b/src/components/core/ui/card.tsx
@@ -2,45 +2,67 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * PANEL — the container surface of the design system.
+ *
+ * Opaque fill, one hairline, 6px radius, no shadow at rest. The previous card
+ * was a glass panel (translucent white film + 12px backdrop blur + a floating
+ * shadow + a 2px hover lift). Three reasons that is gone:
+ *
+ *  - A translucent panel has no fixed contrast ratio. The legibility of a table
+ *    row inside it depended on whatever happened to be scrolling underneath,
+ *    so the same content was compliant in one scroll position and marginal in
+ *    another — and no static audit can catch that.
+ *  - `backdrop-filter` forces the compositor to re-sample everything behind the
+ *    element. On a dashboard with a dozen panels that is a dozen live blurs.
+ *  - The 2px hover lift meant passing the mouse across a grid rippled it.
+ *
+ * A panel is a quiet frame; the data inside it is the thing worth looking at.
+ * For a panel that IS a click target, add `panel-interactive` (or wrap it in an
+ * <a>/<button> — the CSS picks that up) to get a border+fill hover, still with
+ * no movement.
+ */
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, style, ...props }, ref) => (
+>(({ className, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
-      'gradient-border rounded-2xl transition-all duration-300',
+      'rounded-md border border-hairline bg-card text-card-foreground',
       className,
     )}
-    style={{
-      background: 'var(--glass-background)',
-      backdropFilter: 'blur(var(--glass-blur))',
-      border: '1px solid transparent',
-      ...style,
-    }}
     {...props}
   />
 ));
 Card.displayName = 'Card';
 
-// Canonical card header: a bordered header bar with tight vertical padding. Horizontal padding
-// stays px-6 so the header's left edge aligns with CardContent's p-6. Cards that want a
-// borderless header (e.g. mini KPI tiles) can override with `border-0`.
+/**
+ * Header bar of a panel: title/description on the left, actions on the right.
+ * Laid out as a row so `<CardAction>` needs no absolute positioning, and kept
+ * flex-col-friendly for the many existing call sites that pass stacked children.
+ */
 const CardHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex flex-col space-y-1 px-6 py-4 border-b border-border/60', className)}
+    className={cn(
+      'flex flex-col gap-1 px-4 py-3 border-b border-hairline',
+      className,
+    )}
     {...props}
   />
 ));
 CardHeader.displayName = 'CardHeader';
 
-// Canonical card title: 16px. This is THE single card-header size across the platform — do not
-// pass ad-hoc text-* overrides. Page-level gradient headers (PageHeader, 24px) and the compact
-// glass analytics headers (h3 text-sm) are separate, deliberately-distinct tiers.
+/**
+ * Panel title. 14px semibold sans — deliberately NOT the display serif and
+ * deliberately not large. A page has one title (PageHeader, 20px, serif); a
+ * panel header is a label for a region, and eight serif labels down a dashboard
+ * read as eight competing page titles.
+ */
 const CardTitle = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLHeadingElement>
@@ -48,7 +70,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      'text-base font-semibold leading-none tracking-tight',
+      'font-sans text-sm font-semibold leading-tight tracking-tight text-foreground',
       className,
     )}
     {...props}
@@ -62,29 +84,31 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn('text-xs text-muted-foreground', className)}
     {...props}
   />
 ));
 CardDescription.displayName = 'CardDescription';
 
-// Content sits below the bordered header, so it carries its own top padding (p-6, not pt-0).
-// Tables still override to p-0 for edge-to-edge rows.
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('p-6', className)} {...props} />
+  <div ref={ref} className={cn('p-4', className)} {...props} />
 ));
 CardContent.displayName = 'CardContent';
 
+/** Footer bar — sunken so it reads as chrome (pagination, totals, bulk actions). */
 const CardFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex items-center p-6 pt-0', className)}
+    className={cn(
+      'flex items-center gap-2 px-4 py-3 border-t border-hairline',
+      className,
+    )}
     {...props}
   />
 ));

--- a/src/components/core/ui/checkbox.tsx
+++ b/src/components/core/ui/checkbox.tsx
@@ -1,9 +1,24 @@
 import * as React from 'react';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
-import { Check } from 'lucide-react';
+import { Check, Minus } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * CHECKBOX. 16px, 2px radius, neutral hairline at rest and accent when set.
+ *
+ * Two details that matter more than they look:
+ *
+ *  - **An unchecked box is outlined in a NEUTRAL colour, not the accent.** It
+ *    used to be `border-primary`, so an untouched box was drawn in the same
+ *    colour as a checked one — an empty selection column read as fully selected
+ *    at a glance.
+ *  - **Indeterminate gets its own glyph (a dash), not the tick.** Radix renders
+ *    `Indicator` for both `checked` and `indeterminate`, so a tick with nothing
+ *    else to distinguish it says "all rows selected" when the truth is "some".
+ *    On a bulk action — delete, assign, export — that difference is the whole
+ *    question.
+ */
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
@@ -11,15 +26,17 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'peer h-4 w-4 shrink-0 rounded-xs border border-muted-foreground/60 bg-card ring-offset-background transition-colors hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground',
       className,
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator
-      className={cn('flex items-center justify-center text-current')}
-    >
-      <Check className="h-4 w-4" />
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      {props.checked === 'indeterminate' ? (
+        <Minus className="h-3 w-3" strokeWidth={3} />
+      ) : (
+        <Check className="h-3 w-3" strokeWidth={3} />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/src/components/core/ui/command.tsx
+++ b/src/components/core/ui/command.tsx
@@ -28,7 +28,7 @@ interface CommandDialogProps extends DialogProps {
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="overflow-hidden p-0 shadow-overlay">
         {/* Radix requires a Title (and Description) for screen-reader users; the
             command palette is visual, so render them sr-only. Fixes KAI-7V. */}
         <DialogTitle className="sr-only">Command Menu</DialogTitle>

--- a/src/components/core/ui/context-menu.tsx
+++ b/src/components/core/ui/context-menu.tsx
@@ -44,7 +44,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 min-w-[8rem] overflow-hidden rounded-xl border border-hairline bg-popover p-1 text-popover-foreground shadow-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}
@@ -60,7 +60,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 min-w-[8rem] overflow-hidden rounded-xl border border-hairline bg-popover p-1 text-popover-foreground shadow-overlay animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/src/components/core/ui/dialog.tsx
+++ b/src/components/core/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
         // dialog inside the viewport instead of pushing its top (and the close
         // button) off the top edge. Both are mobile-safety floors any modal can
         // still override via className.
-        'fixed left-[50%] top-[50%] z-50 grid grid-cols-1 w-[calc(100%-2rem)] sm:w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid grid-cols-1 w-[calc(100%-2rem)] sm:w-full max-w-lg max-h-[calc(100dvh-2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border border-hairline bg-card p-6 shadow-overlay duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-2xl',
         className,
       )}
       {...props}

--- a/src/components/core/ui/dropdown-menu.tsx
+++ b/src/components/core/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 min-w-[8rem] overflow-hidden rounded-xl border border-hairline bg-popover p-1 text-popover-foreground shadow-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 min-w-[8rem] overflow-hidden rounded-xl border border-hairline bg-popover p-1 text-popover-foreground shadow-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/src/components/core/ui/hover-card.tsx
+++ b/src/components/core/ui/hover-card.tsx
@@ -16,7 +16,7 @@ const HoverCardContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 w-64 rounded-xl border border-hairline bg-popover p-4 text-popover-foreground shadow-overlay outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}

--- a/src/components/core/ui/input.tsx
+++ b/src/components/core/ui/input.tsx
@@ -2,13 +2,33 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * TEXT FIELD. 36px tall, 4px radius, opaque card fill, hairline border,
+ * accent border + a 3px accent halo on focus.
+ *
+ * The old field was a translucent white film — `bg-white/5` over a
+ * `border-white/12` edge. Two consequences: on the light theme a literal white
+ * overlay is invisible, so the field had no discernible edge at all; and `/12`
+ * is not a step in Tailwind's opacity scale, so that border utility compiled to
+ * nothing and the dark theme had no edge either. Fields are painted from tokens
+ * now, so they are correct in both themes and both accents by construction.
+ *
+ * Height, radius, padding and focus treatment are IDENTICAL here, in
+ * `SelectTrigger` and in `Textarea`. A form row that mixes a 40px input with a
+ * 36px select is the most common way a settings page looks broken.
+ */
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
   ({ className, type, ...props }, ref) => {
     return (
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-lg bg-white/5 border border-white/12 px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary/50 disabled:cursor-not-allowed disabled:opacity-50 transition-all duration-200 hover:border-white/20',
+          'flex h-9 w-full rounded-sm border border-hairline bg-card px-2.5 py-1 text-sm text-foreground transition-colors',
+          'file:border-0 file:bg-transparent file:text-sm file:font-semibold file:text-foreground',
+          'placeholder:text-muted-foreground',
+          'hover:border-muted-foreground/50',
+          'focus-visible:border-primary focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-primary/20',
+          'disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/src/components/core/ui/menubar.tsx
+++ b/src/components/core/ui/menubar.tsx
@@ -72,7 +72,7 @@ const MenubarSubContent = React.forwardRef<
   <MenubarPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 min-w-[8rem] overflow-hidden rounded-xl border border-hairline bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className,
     )}
     {...props}
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'z-50 min-w-[12rem] overflow-hidden rounded-xl border border-hairline bg-popover p-1 text-popover-foreground shadow-overlay data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,
         )}
         {...props}

--- a/src/components/core/ui/navigation-menu.tsx
+++ b/src/components/core/ui/navigation-menu.tsx
@@ -86,7 +86,7 @@ const NavigationMenuViewport = React.forwardRef<
   <div className={cn('absolute left-0 top-full flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        'origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]',
+        'origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-xl border border-hairline bg-popover text-popover-foreground shadow-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]',
         className,
       )}
       ref={ref}
@@ -109,7 +109,7 @@ const NavigationMenuIndicator = React.forwardRef<
     )}
     {...props}
   >
-    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
+    <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-overlay" />
   </NavigationMenuPrimitive.Indicator>
 ));
 NavigationMenuIndicator.displayName =

--- a/src/components/core/ui/popover.tsx
+++ b/src/components/core/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 w-72 rounded-xl border border-hairline bg-popover p-4 text-popover-foreground shadow-overlay outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/src/components/core/ui/progress.tsx
+++ b/src/components/core/ui/progress.tsx
@@ -10,13 +10,13 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      'relative h-3 w-full overflow-hidden rounded-full bg-muted shadow-inner',
+      'relative h-1.5 w-full overflow-hidden rounded-full bg-surface-sunken',
       className,
     )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all duration-500 ease-out rounded-full shadow-sm"
+      className="h-full w-full flex-1 rounded-full bg-primary transition-all duration-300 ease-out"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/components/core/ui/select.tsx
+++ b/src/components/core/ui/select.tsx
@@ -19,14 +19,14 @@ const SelectTrigger = React.forwardRef<
     className={cn(
       // Matches Input/Textarea exactly so dropdowns and text fields share the
       // same height, radius, background, and border treatment platform-wide.
-      'flex h-10 w-full items-center justify-between rounded-lg border border-white/12 bg-white/5 px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary/50 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 transition-all duration-200 hover:border-white/20',
+      'flex h-9 w-full items-center justify-between gap-2 rounded-sm border border-hairline bg-card px-2.5 py-1 text-sm text-foreground transition-colors placeholder:text-muted-foreground hover:border-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-[3px] focus:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 text-primary opacity-70" />
+      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-white/12 bg-background text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border border-hairline bg-popover text-foreground shadow-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,

--- a/src/components/core/ui/sheet.tsx
+++ b/src/components/core/ui/sheet.tsx
@@ -33,7 +33,7 @@ const sheetVariants = cva(
   // off-screen (left/right drawers are full height; top/bottom sheets are
   // additionally capped so a tall one can't grow past the viewport and hide its
   // top edge + close button). A consumer can still override via className.
-  'fixed z-50 gap-4 overflow-y-auto bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-50 gap-4 overflow-y-auto bg-background p-6 shadow-overlay transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
     variants: {
       side: {

--- a/src/components/core/ui/switch.tsx
+++ b/src/components/core/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted-foreground/40',
       className,
     )}
     {...props}
@@ -17,7 +17,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
       )}
     />
   </SwitchPrimitives.Root>

--- a/src/components/core/ui/table.tsx
+++ b/src/components/core/ui/table.tsx
@@ -2,14 +2,35 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * DATA TABLE primitives.
+ *
+ * The table is the most-used surface in this platform, so it carries the
+ * density rules for everything else:
+ *
+ *  - **Rows are separated by a hairline, not by a fill.** Zebra striping and
+ *    tinted rows both consume the one visual channel a table needs to keep
+ *    free — the row's own status colour.
+ *  - **The header is a sunken strip with a hard bottom rule**, and it sticks.
+ *    A scrolled table whose header has left the viewport is an unreadable grid
+ *    of numbers; this is the single most valuable 3 lines in the file.
+ *  - **Header labels are 11px semibold, not uppercase.** Uppercase kills word
+ *    shape, which is exactly the cue you use to find a column at a glance.
+ *  - **Cell padding is 12px/10px.** The old 16px/16px row was ~56px tall, so a
+ *    laptop viewport showed nine rows of a hundred-row list.
+ *
+ * `Table` renders its own horizontal scroll container. Never wrap it in
+ * `overflow-hidden` — see tests/unit/responsiveTableOverflow.test.ts for what
+ * that costs on a phone.
+ */
 const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full overflow-x-auto">
     <table
       ref={ref}
-      className={cn('w-full caption-bottom text-sm', className)}
+      className={cn('w-full caption-bottom border-collapse text-sm', className)}
       {...props}
     />
   </div>
@@ -20,7 +41,18 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('sticky top-0 bg-muted/50 border-b border-border/50 [&_tr]:border-0', className)} {...props} />
+  <thead
+    ref={ref}
+    className={cn(
+      'sticky top-0 z-10 bg-surface-sunken [&_tr]:border-0',
+      // The rule lives on the <th> (border-b) rather than the <thead>: a
+      // sticky <thead>'s own border is painted at its ORIGINAL position by
+      // most engines, so it detaches from the strip as soon as you scroll.
+      '[&_th]:border-b [&_th]:border-hairline',
+      className,
+    )}
+    {...props}
+  />
 ));
 TableHeader.displayName = 'TableHeader';
 
@@ -43,7 +75,7 @@ const TableFooter = React.forwardRef<
   <tfoot
     ref={ref}
     className={cn(
-      'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+      'border-t border-hairline bg-surface-sunken font-semibold [&>tr]:last:border-b-0',
       className,
     )}
     {...props}
@@ -58,7 +90,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+      'border-b border-hairline transition-colors hover:bg-surface-hover data-[state=selected]:bg-primary/10',
       className,
     )}
     {...props}
@@ -73,7 +105,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-10 px-4 text-left align-middle text-xs font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      'h-9 whitespace-nowrap px-3 text-left align-middle text-[11px] font-semibold tracking-wide text-muted-foreground [&:has([role=checkbox])]:w-9 [&:has([role=checkbox])]:pr-0',
       className,
     )}
     {...props}
@@ -87,7 +119,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn('p-3 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    className={cn(
+      'px-3 py-2.5 align-middle text-sm [&:has([role=checkbox])]:w-9 [&:has([role=checkbox])]:pr-0',
+      className,
+    )}
     {...props}
   />
 ));
@@ -99,7 +134,7 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    className={cn('mt-3 text-xs text-muted-foreground', className)}
     {...props}
   />
 ));

--- a/src/components/core/ui/tabs.tsx
+++ b/src/components/core/ui/tabs.tsx
@@ -101,9 +101,16 @@ const TabsList = React.forwardRef<
       ref={setRefs}
       data-overflow={overflow}
       className={cn(
-        // No container background — tabs sit flat on the page; the active
-        // trigger alone carries the light-grey highlight (see TabsTrigger).
-        'inline-flex h-10 items-center justify-center rounded-md p-1 text-muted-foreground',
+        // A tab strip is a NAVIGATION rule, so it renders as one: no container
+        // fill, no padding box, a hairline running the full width with the
+        // triggers sitting on it. The active indicator is a 2px accent segment
+        // of that same rule (see index.css) — which is why the list needs the
+        // border and the trigger needs the height, not the other way round.
+        'inline-flex h-9 w-full items-center justify-start gap-1 border-b border-hairline text-muted-foreground',
+        // A VERTICAL rail (Finance's section nav) gets the rule on its trailing
+        // edge instead, and no fixed height — a 36px-tall stack of 19 sections
+        // is not a thing. Radix stamps data-orientation on the list itself.
+        'data-[orientation=vertical]:h-auto data-[orientation=vertical]:flex-col data-[orientation=vertical]:items-stretch data-[orientation=vertical]:gap-0 data-[orientation=vertical]:border-b-0 data-[orientation=vertical]:border-r',
         className,
       )}
       {...props}
@@ -119,15 +126,21 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      // Mimic the header-menu nav exactly: hover AND active both render the
-      // blue→red brand gradient — the global `.bg-primary` / `.hover:bg-primary:hover`
-      // rule in index.css turns these bg-primary utilities into the gradient.
-      // Covers horizontal tabs and the vertical/sidebar tabs (e.g. Finance),
-      // since they all use this single TabsTrigger.
-      // min-h-9 on mobile only: the mobile CSS turns tab rows into a horizontally
-      // scrollable strip, and a 32px target inside a scroll container gets
-      // mis-tapped as a scroll instead of an activation.
-      'inline-flex min-h-9 md:min-h-0 items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-primary hover:text-primary-foreground data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm',
+      // UNDERLINE tabs. The colours, the indicator and the active weight are
+      // all in index.css, keyed off `[role="tab"]`, so the same treatment
+      // reaches every tab-shaped nav in the platform — Radix Tabs here, the
+      // Finance vertical rail, and the hand-rolled strips that never imported
+      // this file. What lives here is only the box: size, padding, focus.
+      //
+      // Why not a filled pill (what this used to be): a filled accent pill is
+      // the exact silhouette of a primary button, so "the section you are in"
+      // and "the button you should press" were the same object. An underline
+      // is a location marker and reads as one instantly.
+      //
+      // min-h-9 on mobile: the mobile stylesheet turns a tab row into a
+      // horizontal scroll strip, and a short target inside a scroll container
+      // gets swallowed as a drag instead of a tap.
+      'relative inline-flex min-h-9 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap px-3 py-1.5 text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50 md:min-h-0',
       className,
     )}
     {...props}
@@ -142,7 +155,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'mt-4 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
       className,
     )}
     {...props}

--- a/src/components/core/ui/textarea.tsx
+++ b/src/components/core/ui/textarea.tsx
@@ -26,7 +26,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'flex min-h-[72px] w-full rounded-lg border border-white/12 bg-white/5 px-3 py-2 text-sm text-foreground ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary/50 hover:border-white/20 disabled:cursor-not-allowed disabled:opacity-50 transition-all duration-200',
+          // Same material as Input/SelectTrigger — token-painted, not a white film.
+          'flex min-h-[72px] w-full rounded-sm border border-hairline bg-card px-2.5 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground hover:border-muted-foreground/50 focus-visible:border-primary focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-primary/20 disabled:cursor-not-allowed disabled:opacity-50',
           RESIZE_CLASS[resize],
           // Placed last so a caller's own resize-* utility still wins (cn is tailwind-merge).
           className,

--- a/src/components/core/ui/tooltip.tsx
+++ b/src/components/core/ui/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-[9999] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-[9999] overflow-hidden rounded-xl border border-hairline bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-overlay animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/src/components/features/ai/AgentHub.tsx
+++ b/src/components/features/ai/AgentHub.tsx
@@ -5020,7 +5020,7 @@ export const AgentHub: React.FC<AgentHubProps> = ({
         <button
           onClick={() => setChatCollapsed(false)}
           title="Show chat"
-          className="flex w-10 shrink-0 flex-col items-center gap-2 border-l border-white/8 bg-sidebar py-4 text-muted-foreground transition-colors hover:text-foreground"
+          className="flex w-10 shrink-0 flex-col items-center gap-2 border-l border-hairline bg-sidebar py-4 text-muted-foreground transition-colors hover:text-foreground"
         >
           <PanelRightOpen className="h-5 w-5" />
           <span className="[writing-mode:vertical-rl] text-[11px] font-medium uppercase tracking-wider">Chat</span>
@@ -5035,13 +5035,13 @@ export const AgentHub: React.FC<AgentHubProps> = ({
           // Right rail beside the canvas on desktop; full width on mobile (where
           // the canvas is a separate, mutually-exclusive pane).
           !chatPaneHidden && canvasShown && !isMobile
-            ? 'w-full max-w-[400px] shrink-0 border-l border-white/8'
+            ? 'w-full max-w-[400px] shrink-0 border-l border-hairline'
             : 'flex-1 min-w-0',
         )}
       >
         {/* Studio header — agent identity + conversation manager launcher */}
         <div className={cn(
-          'flex items-center px-3 sm:px-4 py-2.5 border-b border-white/8 shrink-0',
+          'flex items-center px-3 sm:px-4 py-2.5 border-b border-hairline shrink-0',
           railMode ? 'gap-1.5' : 'gap-3',
         )}>
           <AgentAvatar agentId={currentAgent?.id} className={cn('w-9 h-9 flex-shrink-0', currentAgent?.color)} />

--- a/src/components/features/ai/ProgressiveImageGrid.tsx
+++ b/src/components/features/ai/ProgressiveImageGrid.tsx
@@ -1768,7 +1768,7 @@ const ProgressiveImageGridInner: React.FC<ProgressiveImageGridProps> = ({
       {lightboxUrl && (
         <div
           role="presentation"
-          className="fixed inset-0 z-[200] bg-black/92 flex items-center justify-center"
+          className="fixed inset-0 z-[200] bg-black/90 flex items-center justify-center"
           onClick={() => setLightboxUrl(null)}
         >
           <img

--- a/src/components/features/dashboard/HeroSection.tsx
+++ b/src/components/features/dashboard/HeroSection.tsx
@@ -20,7 +20,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({ onNavigate }) => {
   }
 
   return (
-    <div className="relative overflow-hidden h-full min-h-[280px] sm:min-h-[400px] flex items-center rounded-2xl border border-white/8 bg-card">
+    <div className="relative overflow-hidden h-full min-h-[280px] sm:min-h-[400px] flex items-center rounded-2xl border border-hairline bg-card">
       {/* Brand glow backdrop for depth — soft radial accents, not decorative motion */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -65,7 +65,7 @@ export const HeroSection: React.FC<HeroSectionProps> = ({ onNavigate }) => {
             <button
               key={task.path}
               onClick={() => onNavigate(task.path)}
-              className="group flex items-center gap-3 rounded-xl border border-white/8 bg-background/50 p-3 text-left transition-colors hover:border-primary/40 hover:bg-background/80"
+              className="group flex items-center gap-3 rounded-xl border border-hairline bg-background/50 p-3 text-left transition-colors hover:border-primary/40 hover:bg-background/80"
             >
               <div className="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
                 <task.icon className="h-4 w-4 text-primary" />

--- a/src/components/features/dashboard/MyOffice.tsx
+++ b/src/components/features/dashboard/MyOffice.tsx
@@ -31,9 +31,9 @@ function money(n: number, currency = 'EUR'): string {
 }
 
 const TONE_STYLES: Record<InsightTone, { icon: React.ComponentType<{ className?: string }>; cls: string; chip: string }> = {
-  warning: { icon: AlertTriangle, cls: 'text-amber-400', chip: 'bg-amber-400/12' },
-  positive: { icon: TrendingUp, cls: 'text-emerald-400', chip: 'bg-emerald-400/12' },
-  tip: { icon: Lightbulb, cls: 'text-primary', chip: 'bg-primary/12' },
+  warning: { icon: AlertTriangle, cls: 'text-amber-400', chip: 'bg-amber-400/[0.12]' },
+  positive: { icon: TrendingUp, cls: 'text-emerald-400', chip: 'bg-emerald-400/[0.12]' },
+  tip: { icon: Lightbulb, cls: 'text-primary', chip: 'bg-primary/[0.12]' },
   info: { icon: Info, cls: 'text-muted-foreground', chip: 'bg-muted' },
 };
 
@@ -304,10 +304,10 @@ const MyOfficeImpl: React.FC = () => {
       <QuickAccess />
 
       {/* KAI insights */}
-      <div className="mt-1 pt-4 border-t border-white/8 flex-1 flex flex-col">
+      <div className="mt-1 pt-4 border-t border-hairline flex-1 flex flex-col">
         <div className="flex items-center justify-between mb-3">
           <span
-            className="inline-flex items-center gap-1.5 text-[11px] text-primary bg-primary/12 border border-primary/25 rounded-full px-2.5 py-1"
+            className="inline-flex items-center gap-1.5 text-[11px] text-primary bg-primary/[0.12] border border-primary/25 rounded-full px-2.5 py-1"
             style={{ fontWeight: 600 }}
           >
             <Sparkles className="h-3 w-3" /> KAI · Live insights

--- a/src/components/features/dashboard/QuickAccess.tsx
+++ b/src/components/features/dashboard/QuickAccess.tsx
@@ -36,7 +36,7 @@ export const QuickAccess: React.FC = () => (
           key={t.to}
           to={t.to}
           title={t.label}
-          className="group flex flex-col items-center gap-1.5 rounded-xl border border-white/8 bg-background/40 px-1 py-2.5 transition-colors hover:border-primary/40 hover:bg-background/70"
+          className="group flex flex-col items-center gap-1.5 rounded-xl border border-hairline bg-background/40 px-1 py-2.5 transition-colors hover:border-primary/40 hover:bg-background/70"
         >
           <t.icon className="h-4 w-4 text-primary shrink-0" />
           {/* 9px is small, but the tile is 1/5 of a narrow column and the icon

--- a/src/components/features/dashboard/StatBlock.tsx
+++ b/src/components/features/dashboard/StatBlock.tsx
@@ -58,7 +58,7 @@ export const StatBlock: React.FC<StatBlockProps> = ({
   ];
 
   return (
-    <div className="rounded-xl border border-white/8 bg-background/40 p-3.5 flex flex-col">
+    <div className="rounded-xl border border-hairline bg-background/40 p-3.5 flex flex-col">
       <div className="flex items-center gap-2 mb-2.5">
         <span className="w-6 h-6 rounded-md bg-primary/10 grid place-items-center shrink-0">
           <Icon className="h-3.5 w-3.5 text-primary" />

--- a/src/components/features/discover/ProfileModal.tsx
+++ b/src/components/features/discover/ProfileModal.tsx
@@ -288,7 +288,7 @@ export function ProfileModal({ userId, onClose }: ProfileModalProps) {
             style={{ background: 'var(--brand-gradient)' }}
           >
             <div className="absolute -top-12 -left-12 w-72 h-72 rounded-full bg-white/10 blur-3xl pointer-events-none" />
-            <div className="absolute -bottom-10 right-1/3 w-80 h-80 rounded-full bg-white/8 blur-3xl pointer-events-none" />
+            <div className="absolute -bottom-10 right-1/3 w-80 h-80 rounded-full bg-surface-hover blur-3xl pointer-events-none" />
             <div className="absolute top-8 right-16 w-40 h-40 rounded-full bg-accent/20 blur-2xl pointer-events-none" />
 
             {/* Top-right buttons */}

--- a/src/components/shared/PageHeader.tsx
+++ b/src/components/shared/PageHeader.tsx
@@ -1,32 +1,86 @@
 import React from 'react';
+import { ChevronRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+export interface PageHeaderCrumb {
+  label: string;
+  /** Omit on the current page — a crumb with no `to` renders as plain text. */
+  to?: string;
+}
 
 interface PageHeaderProps {
   icon: React.ComponentType<{ className?: string }>;
   title: string;
   subtitle?: string;
+  /**
+   * Ancestor trail, rendered above the title. A deep record page ("this
+   * invoice, inside Finance") is otherwise indistinguishable from a top-level
+   * one, and the back button is the only way out.
+   */
+  breadcrumbs?: PageHeaderCrumb[];
   /** Custom action buttons rendered on the right of the title row (e.g. "New MoodBoard") */
   actions?: React.ReactNode;
-  /** Extra content rendered below the title row (e.g. search/filter bar) */
+  /** Extra content rendered below the title row (e.g. a tab strip or filter bar) */
   children?: React.ReactNode;
 }
 
-export function PageHeader({ icon: Icon, title, subtitle, actions, children }: PageHeaderProps) {
+/**
+ * PAGE HEADER — the identity band at the top of every page.
+ *
+ * This is the ONE surface that still uses the display serif and still gets to
+ * be a little larger than the UI around it, because it answers "where am I".
+ * Everything else in the header is chrome: 20px title, 12px subtitle, actions
+ * right-aligned, one hairline underneath. The icon sits in a small tinted
+ * square rather than a coloured circle — a circle at this size reads as an
+ * avatar, and this is not a person.
+ *
+ * It deliberately does NOT carry the brand gradient any more. A gradient band
+ * across the top of every screen makes each page announce the product instead
+ * of announcing itself, and it collided with the page's own content colours.
+ */
+export function PageHeader({
+  icon: Icon,
+  title,
+  subtitle,
+  breadcrumbs,
+  actions,
+  children,
+}: PageHeaderProps) {
   return (
-    <section className="px-4 sm:px-6 py-3 sm:py-4 border-b border-white/8">
+    <section className="border-b border-hairline bg-card px-4 pt-3 sm:px-6">
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <nav aria-label="Breadcrumb" className="mb-1.5 flex items-center gap-1 text-xs text-muted-foreground">
+          {breadcrumbs.map((crumb, i) => (
+            <React.Fragment key={`${crumb.label}-${i}`}>
+              {i > 0 && <ChevronRight className="h-3 w-3 shrink-0 opacity-60" aria-hidden="true" />}
+              {crumb.to ? (
+                <Link to={crumb.to} className="truncate hover:text-primary hover:underline">
+                  {crumb.label}
+                </Link>
+              ) : (
+                <span className="truncate">{crumb.label}</span>
+              )}
+            </React.Fragment>
+          ))}
+        </nav>
+      )}
+
       {/* On mobile the actions drop to their own row (and may wrap) so a wide
           primary button is never clipped off the right edge; from sm up it sits
           inline on the right. The title truncates rather than pushing actions
           off-screen. */}
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <div className="flex flex-col gap-2 pb-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         {/* Left: page icon + title */}
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="w-9 h-9 rounded-lg bg-primary/15 flex items-center justify-center shrink-0">
-            <Icon className="h-5 w-5 text-primary" />
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-primary/10">
+            <Icon className="h-4 w-4 text-primary" />
           </div>
           <div className="min-w-0">
-            <h1 className="text-lg font-light text-foreground tracking-tight truncate">{title}</h1>
+            <h1 className="truncate font-display text-xl font-semibold leading-tight tracking-tight text-foreground">
+              {title}
+            </h1>
             {subtitle && (
-              <p className="text-xs text-muted-foreground mt-0.5 hidden sm:block">{subtitle}</p>
+              <p className="mt-0.5 hidden truncate text-xs text-muted-foreground sm:block">{subtitle}</p>
             )}
           </div>
         </div>
@@ -36,11 +90,13 @@ export function PageHeader({ icon: Icon, title, subtitle, actions, children }: P
             quote with submit / share / email / download) never overflow at narrow
             and mid widths; on wide screens they stay on one line and align right. */}
         {actions && (
-          <div className="flex items-center gap-2 flex-wrap sm:justify-end">{actions}</div>
+          <div className="flex flex-wrap items-center gap-2 sm:justify-end">{actions}</div>
         )}
       </div>
 
-      {children && <div className="mt-3">{children}</div>}
+      {/* A tab strip passed as children sits flush with the header's own bottom
+          rule, so the two read as one band rather than two stacked borders. */}
+      {children && <div className="-mb-px">{children}</div>}
     </section>
   );
 }

--- a/src/components/shared/SectionHeader.tsx
+++ b/src/components/shared/SectionHeader.tsx
@@ -13,22 +13,23 @@ interface SectionHeaderProps {
 
 /**
  * Canonical secondary / content header — the single lead-in for a tab or a page section,
- * sitting BELOW the gradient `PageHeader`. This is the "section" tier of the header scale:
+ * sitting BELOW the `PageHeader`. This is the "section" tier of the type scale:
  *
- *   page 24px (PageHeader gradient bar)  ›  SECTION 18px (this)  ›  card 16px (CardTitle)
+ *   page 20px (PageHeader, serif)  ›  SECTION 16px (this)  ›  panel 14px (CardTitle)
  *
- * Use it as the first element of every tab / settings pane / page section so every view
- * opens the same way. Do NOT hand-roll `h1/h2/h3` section headers — they drifted to a
- * dozen different sizes/weights, which is exactly what this replaces.
+ * Each tier is one step down and each is a different JOB (you are here / this region /
+ * this box). Use it as the first element of every tab, settings pane and page section so
+ * every view opens the same way. Do NOT hand-roll `h1/h2/h3` section headers — they
+ * drifted to a dozen different sizes and weights, which is what this replaces.
  */
 export const SectionHeader: React.FC<SectionHeaderProps> = ({ icon: Icon, title, subtitle, actions, className }) => (
-  <div className={cn('mb-6 flex flex-wrap items-start justify-between gap-3', className)}>
+  <div className={cn('mb-4 flex flex-wrap items-start justify-between gap-3', className)}>
     <div className="min-w-0">
-      <h2 className="flex items-center gap-2 text-lg font-semibold tracking-tight">
-        {Icon && <Icon className="h-5 w-5 shrink-0 text-primary" />}
+      <h2 className="flex items-center gap-2 font-sans text-base font-semibold tracking-tight">
+        {Icon && <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />}
         {title}
       </h2>
-      {subtitle && <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{subtitle}</p>}
+      {subtitle && <p className="mt-0.5 max-w-2xl text-xs text-muted-foreground">{subtitle}</p>}
     </div>
     {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
   </div>

--- a/src/index.css
+++ b/src/index.css
@@ -160,23 +160,29 @@ All colors MUST be HSL.
 
     /* ===== LAYOUT SYSTEM ===== */
     --page-max-width: 1400px;
-    --page-padding-x: var(--space-lg);     /* Left/Right: 32px */
+    --page-padding-x: var(--space-md);     /* Left/Right: 24px */
     --page-padding-y: 0;                   /* Top/Bottom: 0 (full height) */
-    --grid-gap: var(--space-md);           /* Grid gap: 24px */
-    --card-padding: var(--space-md);       /* Card padding: 24px */
-    --section-spacing: var(--space-md);    /* Section spacing: 24px (REDUCED from 48px) */
+    --grid-gap: var(--space-sm);           /* Grid gap: 16px — dense product grid */
+    --card-padding: 1.25rem;               /* Card padding: 20px */
+    --section-spacing: var(--space-sm);    /* Section spacing: 16px */
     --hero-margin-x: var(--space-lg);      /* Hero left/right: 32px */
     --hero-margin-bottom: var(--space-md); /* Hero bottom: 24px (REDUCED from 48px) */
     --hero-padding-y: var(--space-lg);     /* Hero top/bottom: 32px (REDUCED from 64px) */
     --hero-padding-x: var(--space-md);     /* Hero left/right: 24px */
 
-    /* ===== BORDER RADIUS ===== */
-    --radius-sm: 0.5rem;   /* 8px */
-    --radius-md: 0.75rem;  /* 12px */
-    --radius-lg: 1rem;     /* 16px */
-    --radius-xl: 1.5rem;   /* 24px */
-    --radius-2xl: 2rem;    /* 32px */
-    --radius-full: 9999px; /* Fully rounded */
+    /* ===== BORDER RADIUS =====
+       Crisp product-UI corners. The old scale (8→32px) rounded a data table's
+       container harder than a macOS window; at 32px a card stops reading as a
+       panel and starts reading as a bubble. Controls are 4px, panels 6px,
+       overlays 8–10px. `--radius-full` stays for avatars, dots and status
+       pips — the only things that should ever be a circle. */
+    --radius-xs: 0.125rem; /* 2px  — checkbox, tag */
+    --radius-sm: 0.25rem;  /* 4px  — button, input, select */
+    --radius-md: 0.375rem; /* 6px  — card, panel, table container */
+    --radius-lg: 0.5rem;   /* 8px  — dialog, popover, dropdown */
+    --radius-xl: 0.625rem; /* 10px — modal, large sheet */
+    --radius-2xl: 0.75rem; /* 12px — full-bleed hero panel */
+    --radius-full: 9999px; /* avatars, dots, pips ONLY */
 
     /* ===== FONT SIZES ===== */
     --text-xs: 0.75rem;    /* 12px */
@@ -263,7 +269,17 @@ All colors MUST be HSL.
     --input: 260 16% 18%;
     --ring: 335 74% 60%;  /* Focus ring — magenta accent */
 
-    --radius: 0.5rem;  /* 8px */
+    /* Row / list / card hover. Dark had no --surface-hover at all (only light
+       defined one), so every "hover tint" in the app was a hand-picked
+       white/NN. One token, both themes. */
+    --surface-hover: 264 20% 12%;
+    /* The line under a table header, between list rows, around a card. One
+       hairline value everywhere is most of what makes a dense UI read as tidy. */
+    --hairline: 260 16% 18%;
+    /* Table header strip + any "sunken" sub-surface (toolbars, filter rows). */
+    --surface-sunken: 262 22% 10%;
+
+    --radius: 0.375rem;  /* 6px — see the radius scale above */
 
     /* Sidebar/TopNav - Dark theme */
     --sidebar-background: 264 22% 7%;  /* rail — slightly lifted from bg */
@@ -291,13 +307,18 @@ All colors MUST be HSL.
     --gradient-sage: linear-gradient(180deg, rgba(198, 208, 188, 0.06) 0%, rgba(198, 208, 188, 0.01) 100%);
     --gradient-gray: linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0.005) 100%);
 
-    /* Shadows - Deeper for dark theme */
-    --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.2);
-    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.3);
-    --shadow: 0 2px 4px 0 rgb(0 0 0 / 0.3);
-    --shadow-md: 0 3px 6px 0 rgb(0 0 0 / 0.4);
-    --shadow-lg: 0 4px 8px 0 rgb(0 0 0 / 0.5);
-    --shadow-card: 0 1px 3px 0 rgb(0 0 0 / 0.3);
+    /* Shadows — a product UI separates panels with a HAIRLINE, and uses shadow
+       only for things that genuinely float (menus, dialogs, popovers). A resting
+       card casts almost nothing; that is what stops a dashboard of 12 tiles from
+       looking like 12 floating stickers. */
+    --shadow-xs: 0 1px 1px 0 rgb(0 0 0 / 0.18);
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.22);
+    --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.26);
+    --shadow-md: 0 2px 6px -1px rgb(0 0 0 / 0.32);
+    --shadow-lg: 0 8px 20px -6px rgb(0 0 0 / 0.45);
+    --shadow-card: none;
+    /* Floating layers only — dropdown, popover, dialog, toast. */
+    --shadow-overlay: 0 10px 28px -8px rgb(0 0 0 / 0.55), 0 2px 8px -2px rgb(0 0 0 / 0.4);
 
     /* Animation */
     --transition-smooth: all 0.15s ease;
@@ -352,14 +373,24 @@ All colors MUST be HSL.
     --badge-draft-text: 0 0% 60%;
     --badge-draft-border: 0 0% 25%;
 
-    /* ===== GLASSMORPHISM SYSTEM (Dark) ===== */
-    --glass-background: rgba(255, 255, 255, 0.05);
-    --glass-blur: 12px;
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+    /* ===== SURFACE SYSTEM (Dark) =====
+       These four variables used to describe a GLASS panel: a translucent white
+       film over a 12px backdrop-blur. Every card, stat tile, table container and
+       modal in the platform reads them, which is why retiring glass in favour of
+       an opaque, hairlined panel is a four-line change here rather than a sweep
+       through 640 components. The names are kept for exactly that reason — the
+       consumers are unchanged, the material is not.
 
-    /* ===== REFINED SHADOWS (Dark) ===== */
-    --shadow-premium: 0 10px 40px -10px rgba(0, 0, 0, 0.4), 0 5px 20px -5px rgba(0, 0, 0, 0.3);
+       Why opaque: a translucent panel has no fixed contrast ratio. Its text
+       contrast depends on whatever scrolls underneath it, so the same table row
+       is legible over one card and marginal over another, and no audit can pin
+       it. Data surfaces are opaque. */
+    --glass-background: hsl(var(--card));
+    --glass-blur: 0px;
+    --glass-border: hsl(var(--hairline));
+    --glass-shadow: none;
+
+    --shadow-premium: var(--shadow-md);
   }
 
 .dark {
@@ -451,13 +482,14 @@ All colors MUST be HSL.
     --gradient-sage: linear-gradient(180deg, rgba(120, 140, 100, 0.07) 0%, rgba(120, 140, 100, 0.01) 100%);
     --gradient-gray: linear-gradient(180deg, rgba(0, 0, 0, 0.035) 0%, rgba(0, 0, 0, 0.006) 100%);
 
-    /* Shadows — lighter, lower alpha for light surfaces */
-    --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.08);
-    --shadow: 0 2px 4px 0 rgb(0 0 0 / 0.08);
-    --shadow-md: 0 3px 6px 0 rgb(0 0 0 / 0.10);
-    --shadow-lg: 0 4px 12px 0 rgb(0 0 0 / 0.12);
-    --shadow-card: 0 1px 3px 0 rgb(0 0 0 / 0.07);
+    /* Shadows — hairline-first, same as dark. See the dark block for why. */
+    --shadow-xs: 0 1px 1px 0 rgb(31 30 22 / 0.04);
+    --shadow-sm: 0 1px 2px 0 rgb(31 30 22 / 0.06);
+    --shadow: 0 1px 3px 0 rgb(31 30 22 / 0.07);
+    --shadow-md: 0 2px 6px -1px rgb(31 30 22 / 0.09);
+    --shadow-lg: 0 8px 20px -6px rgb(31 30 22 / 0.14);
+    --shadow-card: none;
+    --shadow-overlay: 0 10px 28px -8px rgb(31 30 22 / 0.18), 0 2px 8px -2px rgb(31 30 22 / 0.10);
 
     /* Status colors — saturated foreground + pale tinted backgrounds */
     --success: 142 65% 35%;
@@ -508,16 +540,15 @@ All colors MUST be HSL.
     --badge-draft-text: 0 0% 40%;
     --badge-draft-border: 0 0% 82%;
 
-    /* ===== GLASSMORPHISM SYSTEM (Light) ===== */
-    /* Warm frosted ivory, translucent enough that the gradient canvas tints
-       through the glass panels (glass-over-gradient look). */
-    --glass-background: rgba(250, 248, 240, 0.52);
-    --glass-blur: 12px;
-    --glass-border: rgba(0, 0, 0, 0.07);
-    --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.08);
+    /* ===== SURFACE SYSTEM (Light) ===== */
+    --hairline: 46 18% 82%;
+    --surface-sunken: 44 24% 91%;
+    --glass-background: hsl(var(--card));
+    --glass-blur: 0px;
+    --glass-border: hsl(var(--hairline));
+    --glass-shadow: none;
 
-    /* ===== REFINED SHADOWS (Light) ===== */
-    --shadow-premium: 0 10px 40px -10px rgba(0, 0, 0, 0.14), 0 5px 20px -5px rgba(0, 0, 0, 0.08);
+    --shadow-premium: var(--shadow-md);
   }
 
   /* ========================================
@@ -558,6 +589,8 @@ All colors MUST be HSL.
     --border: 214 25% 88%;           /* #dbe1ea cool hairlines */
     --input: 214 25% 88%;
     --ring: 218 74% 46%;
+    --hairline: 214 25% 88%;
+    --surface-sunken: 214 32% 96%;
 
     --sidebar-background: 0 0% 100%;
     --sidebar-foreground: 215 16% 42%;
@@ -599,6 +632,9 @@ All colors MUST be HSL.
     --border: 217 25% 18%;
     --input: 217 25% 18%;
     --ring: 212 74% 54%;
+    --hairline: 217 25% 18%;
+    --surface-hover: 220 30% 13%;
+    --surface-sunken: 220 32% 11%;
 
     --sidebar-background: 220 34% 8%;
     --sidebar-foreground: 215 14% 60%;
@@ -627,43 +663,40 @@ All colors MUST be HSL.
     font-weight: var(--font-normal);
   }
 
-  h1, h2, h3, h4, h5, h6 {
+  /* IDENTITY headings (h1/h2) keep the brand slab serif — page titles, hero
+     copy, marketing pages. UI-CHROME headings (h3–h6: card titles, section
+     labels, panel headers) are sans, because that is what an application
+     surface reads as. Mixing a serif into a dense data UI is the single
+     loudest "this is not a product UI" signal; the brand still lands on
+     every page title. Opt a chrome heading back in with `font-display`. */
+  h1, h2 {
     font-family: var(--font-display);   /* Aleo — slab-serif display face */
     font-weight: var(--font-semibold);  /* 600 → resolves to Aleo Bold (700) */
-    letter-spacing: -0.01em;
+    letter-spacing: -0.012em;
+  }
+
+  h3, h4, h5, h6 {
+    font-family: var(--font-sans);
+    font-weight: var(--font-semibold);
+    letter-spacing: -0.006em;
   }
 
   strong, b {
-    font-weight: var(--font-medium);  /* Medium weight for emphasis (500) */
+    font-weight: var(--font-semibold);
   }
 
   p, span, div {
     font-weight: var(--font-normal);  /* Regular weight for body text */
   }
 
-  /* ===== GLOBAL LIGHTER FONT WEIGHT OVERRIDES ===== */
-  /* Make all bold/semibold/medium classes lighter across the entire app */
-  /* This ensures consistency without changing every component manually */
-
-  .font-black {
-    font-weight: var(--font-light) !important;  /* 300 instead of 900 */
-  }
-
-  .font-extrabold {
-    font-weight: var(--font-light) !important;  /* 300 instead of 800 */
-  }
-
-  .font-bold {
-    font-weight: var(--font-light) !important;  /* 300 instead of 700 */
-  }
-
-  .font-semibold {
-    font-weight: var(--font-normal) !important;  /* 400 instead of 600 */
-  }
-
-  .font-medium {
-    font-weight: var(--font-normal) !important;  /* 400 instead of 500 */
-  }
+  /* NOTE — there used to be a block here that force-downgraded EVERY weight
+     utility (`.font-bold` → 300, `.font-semibold` → 400, `.font-medium` → 400,
+     with !important). It made the whole platform read as one flat, airy weight
+     with no hierarchy: a table header, a total, a KPI number and its caption
+     all rendered identically. Weight IS the hierarchy in a dense data UI —
+     labels 500, headers 600, numbers 600 — so the utilities now mean what they
+     say. Do not reintroduce a global weight override; if something is too
+     heavy, change that component's class. */
 
   /* Hide number input spinners - we use custom +/- buttons instead */
   input[type="number"]::-webkit-inner-spin-button,
@@ -838,85 +871,69 @@ All colors MUST be HSL.
     gap: var(--grid-gap);
   }
 
-  /* Dashboard Card - Dark glass effect */
+  /* ============================================================
+     PANEL — the one container surface.
+     ------------------------------------------------------------
+     Opaque fill + 1px hairline + 6px radius. No blur, no lift, no
+     inset edge-light. `.dashboard-card` keeps its name because ~400
+     call sites use it; the material underneath changed, not the API.
+
+     A panel does NOT move on hover. The old card lifted 2px and
+     lightened its whole surface, which meant: (a) every mouse
+     traverse across a dashboard rippled the layout, and (b) on a
+     card wrapping a table you got two competing highlights, the
+     panel and the row. Movement is reserved for things that are
+     themselves the click target — see `.panel-interactive`.
+     ============================================================ */
   .dashboard-card {
     position: relative;
-    background: var(--glass-background);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border-radius: var(--radius-lg);
+    background: hsl(var(--card));
+    border: 1px solid hsl(var(--hairline));
+    border-radius: var(--radius-md);
     padding: var(--card-padding);
-    transition: var(--transition-bounce);
-    border: 1px solid transparent;
-    /* Layered depth: resting glass shadow + a faint top edge-light for the
-       premium "elevated glass" read from the redesign. */
-    box-shadow: var(--glass-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.045);
+    transition: border-color 0.12s ease, background-color 0.12s ease;
   }
 
-  /* Gradient border ring for boxes — a masked pseudo-element draws the
-     blue→red brand gradient only in the 1px border area. Preserves
-     border-radius and never touches the card's own background, blur or
-     hover state. Add `.gradient-border` to any other box to opt it in. */
-  /* The opt-in classes PLUS any bordered, rounded *container* box that isn't
-     already covered. Scoped to block-level containers with the exact `border`
-     utility + a large rounded corner; excludes form controls (not in the
-     element list) and Tailwind-positioned floating elements (absolute/fixed/
-     sticky) so dropdowns, popovers and tooltips are untouched. */
-  .gradient-border,
-  .section-container,
-  :is(div, section, article, aside, li):where([class~="border"]):where([class*="rounded-lg"], [class*="rounded-xl"], [class*="rounded-2xl"], [class*="rounded-3xl"]):not(.dashboard-card):not(.gradient-border):not([class*="absolute"]):not([class*="fixed"]):not([class*="sticky"]) {
-    position: relative;
+  /* A panel that is ITSELF a link/button (a tile you click through on).
+     Border darkens, background warms a step — still no translation. */
+  .panel-interactive,
+  a > .dashboard-card,
+  button > .dashboard-card {
+    cursor: pointer;
   }
-  .dashboard-card::before,
-  .gradient-border::before,
-  .section-container::before,
-  :is(div, section, article, aside, li):where([class~="border"]):where([class*="rounded-lg"], [class*="rounded-xl"], [class*="rounded-2xl"], [class*="rounded-3xl"]):not(.dashboard-card):not(.gradient-border):not([class*="absolute"]):not([class*="fixed"]):not([class*="sticky"])::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    padding: 1px;
-    background: #00000014;
-    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-            mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-            mask-composite: exclude;
-    pointer-events: none;
-    z-index: 1;
+  .panel-interactive:hover,
+  a:hover > .dashboard-card,
+  button:hover > .dashboard-card {
+    border-color: hsl(var(--primary) / 0.5);
+    background: hsl(var(--surface-hover));
   }
 
-  .dashboard-card:hover {
-    background: rgba(255, 255, 255, 0.08);
-    transform: translateY(-2px);
-    border-color: rgba(255, 255, 255, 0.12);
-    box-shadow: var(--shadow-premium), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  /* Sunken sub-surface: toolbars, filter rows, table headers, footers —
+     anything that sits INSIDE a panel and should recede from it. */
+  .panel-sunken {
+    background: hsl(var(--surface-sunken));
   }
 
-  /* A card that holds a table must NOT repaint/lift its whole surface on
-     hover — only the hovered row should change colour (accessibility). The
-     table's own `tr:hover` / `hover:bg-muted/50` handles the row highlight. */
-  .dashboard-card:has(table):hover {
-    background: var(--glass-background);
-    transform: none;
-    border-color: var(--glass-border);
+  /* `.gradient-border` and the universal bordered-box ring it powered are
+     retired. That selector painted a masked pseudo-element ring onto EVERY
+     bordered, rounded div in the app — on top of the div's own real border —
+     so most containers carried two 1px edges at slightly different colours,
+     and nothing could override the outer one without knowing the rule existed.
+     One real `border` per box. The class is kept as an inert alias so the
+     ~30 call sites that opt in still resolve. */
+  .gradient-border {
+    border: 1px solid hsl(var(--hairline));
+    border-radius: var(--radius-md);
   }
 
-  /* Tabs where item-level card lift should be suppressed */
-  .tab-no-card-lift .dashboard-card:hover {
-    transform: none;
-    box-shadow: var(--glass-shadow);
-  }
-
-  /* Scope wrapper for static content (e.g. profile/detail modals) where the
-     dashboard-card panels are passive — fully neutralise the hover lift/lighten
-     so they don't react like interactive dashboard tiles. */
+  /* Legacy hover-suppression scopes. Panels no longer lift, so these are
+     no-ops kept only so their many call sites keep compiling. */
+  .tab-no-card-lift .dashboard-card:hover,
   .no-card-hover .dashboard-card:hover {
-    background: var(--glass-background);
-    transform: none;
-    border-color: var(--glass-border);
+    background: hsl(var(--card));
+    border-color: hsl(var(--hairline));
   }
 
-  /* Liquid Glass Utility */
   .glass-panel {
     @apply dashboard-card;
   }
@@ -929,16 +946,13 @@ All colors MUST be HSL.
     );
   }
 
-  /* Stat bubbles - Dark glass effect */
+  /* Stat bubbles — opaque tinted chips, same material rules as panels. */
   .stat-bubble {
-    border-radius: var(--radius);
+    border-radius: var(--radius-md);
     padding: var(--card-padding);
-    background: rgba(255, 255, 255, 0.05);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.3);
+    background: hsl(var(--card));
     transition: var(--transition-smooth);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border: 1px solid hsl(var(--hairline));
     color: hsl(var(--foreground));
     font-weight: var(--font-normal);
   }
@@ -972,12 +986,12 @@ All colors MUST be HSL.
     @apply dashboard-card;
   }
 
-  /* Section container - For grouping content (NO BORDERS) */
+  /* Section container - For grouping content */
   .section-container {
-    @apply bg-card rounded-xl space-y-4;
+    @apply bg-card space-y-4;
+    border-radius: var(--radius-md);
     padding: var(--card-padding);
-    box-shadow: var(--shadow-card);
-    border: none;
+    border: 1px solid hsl(var(--hairline));
   }
 
   /* Section spacing - Consistent vertical spacing */
@@ -985,69 +999,87 @@ All colors MUST be HSL.
     margin-bottom: var(--section-spacing);
   }
 
-  /* Sidebar item - Dark theme */
+  /* Sidebar / side-nav item — a left rail row. Active state is a tinted row
+     with an accent bar on the leading edge, not a saturated filled pill: a
+     nav list of 12 filled pills is unreadable, and the bar survives at any
+     row density. */
   .sidebar-item {
-    @apply flex items-center gap-3 px-3 py-2.5 rounded-lg transition-all duration-200;
-    @apply text-sidebar-foreground hover:bg-secondary;
+    @apply relative flex items-center gap-3 px-3 py-2 transition-colors duration-100;
+    @apply text-sidebar-foreground hover:bg-[hsl(var(--surface-hover))] hover:text-foreground;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
   }
 
   .sidebar-item.active {
-    @apply bg-sidebar-accent text-sidebar-accent-foreground;
-    box-shadow: 0 0 10px hsl(var(--sidebar-accent) / 0.3);
+    background: hsl(var(--primary) / 0.10);
+    color: hsl(var(--primary));
+    font-weight: var(--font-semibold);
   }
 
-  /* Primary button - Neon yellow (Paytech style) */
+  .sidebar-item.active::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 15%;
+    bottom: 15%;
+    width: 3px;
+    border-radius: 0 3px 3px 0;
+    background: hsl(var(--primary));
+  }
+
+  /* Primary button */
   .btn-primary {
-    @apply bg-primary text-primary-foreground rounded-lg px-6 py-2.5;
-    @apply font-medium transition-all duration-300;
-    box-shadow: 0 0 10px hsl(var(--primary) / 0.3);
+    @apply bg-primary text-primary-foreground px-4 py-2;
+    @apply font-semibold transition-colors duration-100;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
     border: none;
   }
 
   .btn-primary:hover {
-    box-shadow: 0 0 20px hsl(var(--primary) / 0.45), 0 0 40px hsl(var(--amber) / 0.25);
-    transform: translateY(-1px);
+    background: hsl(var(--primary) / 0.88);
   }
 
-  /* Secondary button - Dark gray */
+  /* Secondary button — outlined in the accent, the standard product-UI pairing
+     for "the other action next to the primary one". */
   .btn-secondary {
-    @apply bg-secondary text-secondary-foreground rounded-lg px-6 py-2.5;
-    @apply font-medium transition-all duration-300;
-    box-shadow: var(--shadow-xs);
-    border: none;
+    @apply bg-transparent text-primary px-4 py-2;
+    @apply font-semibold transition-colors duration-100;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    border: 1px solid hsl(var(--primary));
   }
 
   .btn-secondary:hover {
-    @apply bg-muted;
-    box-shadow: var(--shadow-sm);
-    transform: translateY(-1px);
+    background: hsl(var(--primary) / 0.08);
   }
 
-  /* Outline button - Subtle border */
+  /* Outline button — neutral hairline, for tertiary actions. */
   .btn-outline {
-    @apply bg-card text-foreground rounded-lg px-6 py-2.5;
-    @apply font-medium transition-all duration-300;
-    border: none;
-    box-shadow: var(--shadow-md);
+    @apply bg-card text-foreground px-4 py-2;
+    @apply font-semibold transition-colors duration-100;
+    border-radius: var(--radius-sm);
+    font-size: var(--text-sm);
+    border: 1px solid hsl(var(--hairline));
   }
 
   .btn-outline:hover {
-    @apply bg-secondary;
-    box-shadow: var(--shadow-sm);
+    background: hsl(var(--surface-hover));
   }
 
-  /* Input field - Dark theme */
+  /* Input field */
   .input-dark {
-    @apply bg-input rounded-lg px-4 py-2.5;
+    @apply bg-card px-3 py-2;
     @apply text-foreground placeholder:text-muted-foreground;
-    @apply transition-all duration-200;
-    border: none;
-    box-shadow: var(--shadow-xs);
+    @apply transition-colors duration-100;
+    border-radius: var(--radius-sm);
+    border: 1px solid hsl(var(--hairline));
   }
 
   .input-dark:focus {
-    @apply outline-none ring-2 ring-primary;
-    border: none;
+    @apply outline-none;
+    border-color: hsl(var(--primary));
+    box-shadow: 0 0 0 3px hsl(var(--primary) / 0.16);
   }
 
   /* Search input - Like in the screenshot */
@@ -1056,10 +1088,13 @@ All colors MUST be HSL.
     background-color: hsl(var(--input));
   }
 
-  /* Badge variants - Light theme with excellent contrast */
+  /* Badge variants — squared tag, not a pill. A pill row and a button row are
+     the same silhouette; squaring the tag is what keeps "this is a value" and
+     "this is an action" visually separable in a dense table. */
   .badge {
-    @apply px-3 py-1 rounded-full text-xs border;
-    font-weight: var(--font-medium);
+    @apply px-2 py-0.5 text-xs border;
+    border-radius: var(--radius-xs);
+    font-weight: var(--font-semibold);
   }
 
   .badge-success {
@@ -1097,20 +1132,9 @@ All colors MUST be HSL.
     @apply w-2 h-2 rounded-full;
   }
 
-  .status-dot-success {
-    @apply status-dot bg-success;
-    box-shadow: 0 0 8px hsl(var(--success) / 0.5);
-  }
-
-  .status-dot-warning {
-    @apply status-dot bg-warning;
-    box-shadow: 0 0 8px hsl(var(--warning) / 0.5);
-  }
-
-  .status-dot-error {
-    @apply status-dot bg-error;
-    box-shadow: 0 0 8px hsl(var(--error) / 0.5);
-  }
+  .status-dot-success { @apply status-dot bg-success; }
+  .status-dot-warning { @apply status-dot bg-warning; }
+  .status-dot-error   { @apply status-dot bg-error; }
 
   /* Progress bar */
   .progress-bar {
@@ -1133,26 +1157,27 @@ All colors MUST be HSL.
     @apply progress-fill bg-info;
   }
 
-  /* Table styles - Dark theme */
+  /* Table styles */
   .table-dark {
     @apply w-full;
   }
 
   .table-dark thead {
-    border-bottom: none;
+    background: hsl(var(--surface-sunken));
+    border-bottom: 1px solid hsl(var(--hairline));
   }
 
   .table-dark th {
-    @apply px-4 py-3 text-left text-sm font-medium text-muted-foreground;
+    @apply px-3 py-2 text-left text-xs font-semibold text-muted-foreground;
   }
 
   .table-dark td {
-    @apply px-4 py-4 text-sm text-foreground;
-    border-bottom: none;
+    @apply px-3 py-2.5 text-sm text-foreground;
+    border-bottom: 1px solid hsl(var(--hairline));
   }
 
-  .table-dark tr:hover {
-    @apply bg-secondary/30;
+  .table-dark tbody tr:hover {
+    background: hsl(var(--surface-hover));
   }
 
   /* Chart container */
@@ -1169,21 +1194,19 @@ All colors MUST be HSL.
     background: var(--gradient-blue);
   }
 
-  /* Glow effects */
-  .glow-emerald {
-    box-shadow: 0 0 20px rgba(16, 185, 129, 0.3);
-  }
-
+  /* Glow effects — retired. Neon halos are a marketing-page device; in a data
+     UI they read as an error state. Kept as no-ops for existing call sites. */
+  .glow-emerald,
   .glow-blue {
-    box-shadow: 0 0 20px rgba(59, 130, 246, 0.3);
+    box-shadow: none;
   }
 
   /* Divider */
   .divider {
-    @apply my-6;
+    @apply my-4;
     border-top: none;
     height: 1px;
-    background: hsl(var(--muted));
+    background: hsl(var(--hairline));
   }
 
   /* Animations */
@@ -1473,10 +1496,8 @@ html.light .badge-neutral {
   color: hsl(0 0% 40%);
   border-color: hsl(0 0% 85%);
 }
-html.light .dashboard-card:hover {
-  background: hsl(var(--surface-hover));
-  border-color: rgba(0,0,0,0.08);
-}
+/* (A panel no longer changes on hover unless it is itself the click target —
+   `.panel-interactive` handles that, from tokens, in both themes.) */
 
 /* Unified hover tint (light) — cards, table rows and list items hover to the
    previous page off-white (--surface-hover) so they read clearly against the
@@ -1491,16 +1512,11 @@ html.light .hover\:bg-muted\/80:hover,
 html.light .hover\:bg-accent:hover {
   background-color: hsl(var(--surface-hover)) !important;
 }
-/* Same row-only-hover rule for light theme: a card wrapping a table keeps its
-   resting surface on hover so only the hovered row changes colour. */
-html.light .dashboard-card:has(table):hover {
-  background: var(--glass-background);
-  border-color: var(--glass-border);
-}
+/* Panels are opaque and hairlined in both themes now, so the light theme needs
+   no card-surface patch of its own — the tokens already differ. */
 html.light .stat-bubble {
-  background: rgba(255,255,255,0.7);
-  border-color: rgba(0,0,0,0.06);
-  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.07);
+  background: hsl(var(--card));
+  border-color: hsl(var(--hairline));
 }
 html.light *::-webkit-scrollbar-thumb { background: hsl(var(--muted-foreground) / 0.3); }
 html.light *::-webkit-scrollbar-thumb:hover { background: hsl(var(--muted-foreground) / 0.5); }
@@ -1554,107 +1570,105 @@ html.light .msg-assistant a { color: hsl(var(--primary)); }
    explicitly — see PageHeader.tsx. */
 
 /* ============================================================
-   APP ATMOSPHERE — command-center depth behind every page.
-   A fixed brand-aurora mesh + film grain sit over the solid body
-   ground and below all page content (main is relative z-10). The
-   aurora is driven by --primary so it adapts per theme: a magenta
-   glow on the plum-black dark ground, a soft olive glow on cream.
+   APP CANVAS — a flat, even ground.
+   ------------------------------------------------------------
+   There used to be a fixed "aurora" (three radial brand glows) plus a film
+   grain layer behind every page, and on light a warm cream→sand gradient wash
+   on <body> as well. Three things went wrong with it, and all three are fatal
+   for a data product rather than merely a taste call:
+
+     1. The ground was not one colour, so an opaque panel could never match it
+        and a translucent one changed contrast as it scrolled. Same table, two
+        different legibility results depending on scroll position.
+     2. `background-attachment: fixed` on a full-viewport gradient repaints the
+        whole canvas on every scroll frame.
+     3. Brand glow behind dense numeric content competes with the content for
+        exactly the attention the content needs.
+
+   The canvas is now flat `--background` in both themes and both accents; the
+   brand lives in the accent colour, the logo and the page-header identity —
+   places the eye visits deliberately. The `.app-aurora` / `.app-grain` classes
+   are kept as inert no-ops (Layout no longer renders them).
    ============================================================ */
-.app-aurora {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background:
-    radial-gradient(760px 520px at 85% -8%, hsl(var(--primary) / 0.16), transparent 60%),
-    radial-gradient(620px 460px at 4% 6%, hsl(var(--primary) / 0.09), transparent 60%),
-    radial-gradient(700px 620px at 62% 110%, hsl(var(--primary) / 0.06), transparent 60%);
-}
-html.light .app-aurora {
-  /* Calmed on light — the warm gradient canvas (on body) is the main treatment. */
-  background:
-    radial-gradient(760px 520px at 85% -8%, hsl(var(--primary) / 0.05), transparent 62%);
-}
-
-/* Light theme canvas — warm cream→sand gradient with faint olive/peach corner
-   glows, the ground the frosted (translucent) panels tint against. Dark keeps
-   the plum-black command center. background-attachment:fixed so the gradient
-   stays put while content scrolls over it (cards tint as they pass). */
-html.light body {
-  /* Airy off-white canvas with a darker WARM glow anchored at the bottom-left,
-     fading up-and-out — so the gradient reads clearly while the top/right stay
-     light. Glass panels near the bottom-left tint warmer. */
-  background:
-    radial-gradient(1200px 860px at -8% 110%, rgba(140, 128, 68, 0.34), transparent 58%),
-    radial-gradient(760px 560px at 106% 112%, rgba(208, 152, 104, 0.14), transparent 60%),
-    linear-gradient(180deg, #f8f6f0 0%, #f3efe4 58%, #ede7d7 100%);
-  background-attachment: fixed;
-}
-
-/* Blue accent (light) canvas — WHITE ground with soft blue corner glows, no warm
-   cream. Overrides the warm html.light body above (higher specificity). */
-html.light[data-accent='blue'] body {
-  background:
-    radial-gradient(1100px 820px at -6% 112%, rgba(37, 99, 235, 0.15), transparent 56%),
-    radial-gradient(820px 600px at 108% 110%, rgba(59, 130, 246, 0.10), transparent 58%),
-    radial-gradient(920px 700px at 92% -10%, rgba(37, 99, 235, 0.10), transparent 60%),
-    linear-gradient(180deg, #ffffff 0%, #f5f8fd 58%, #eaf1fb 100%);
-  background-attachment: fixed;
+.app-aurora,
+.app-grain {
+  display: none;
 }
 
 /* ============================================================
-   WARM-GLASS DESIGN HELPERS (glass-over-gradient system)
-   ------------------------------------------------------------
-   .tinted-card  — soft tinted sub-card for a contained module inside a glass
-                   panel (instead of a stark white box). Theme-aware.
-   .tabs-underline — opt-in on a TabsList: renders its triggers as underline
-                   tabs (design-system tab style A), overriding the default
-                   filled bg-primary active. Add to section-tab lists.
+   SUB-SURFACE — a contained module inside a panel.
+   `.tinted-card` keeps its name (many call sites); it is now the sunken
+   sub-surface, one step BELOW the panel it sits in rather than a tint over a
+   gradient. Nesting reads as: page → panel (card) → sub-surface (sunken).
    ============================================================ */
 .tinted-card {
-  background: hsl(var(--muted) / 0.45);
-  border: 1px solid hsl(var(--border) / 0.7);
-  border-radius: var(--radius-md);
-}
-html.light .tinted-card {
-  background: rgba(236, 228, 208, 0.5);
-  border-color: rgba(180, 165, 120, 0.28);
-}
-html.light[data-accent='blue'] .tinted-card {
-  background: rgba(226, 232, 240, 0.5);
-  border-color: rgba(148, 163, 184, 0.28);
+  background: hsl(var(--surface-sunken));
+  border: 1px solid hsl(var(--hairline));
+  border-radius: var(--radius-sm);
 }
 
+/* ============================================================
+   TABS — underline is the DEFAULT, platform-wide.
+   ------------------------------------------------------------
+   Tabs used to render their active trigger as a filled accent pill, which made
+   a tab row and a button row identical objects: the same shape, the same fill,
+   the same weight. On a page carrying both (every record page does) there was
+   no way to tell "you are here" from "press me". An underline says location; a
+   fill says action. That distinction is the single highest-leverage change in
+   this system, so it is the default rather than an opt-in — `.tabs-underline`
+   survives as an alias for the lists that already asked for it.
+
+   The rule set targets `[role="tab"]`, so it covers Radix Tabs, the Finance
+   vertical rail and any nav that reports itself as a tab.
+   ============================================================ */
+[role="tablist"]:not([data-variant="pill"]) > [role="tab"],
 .tabs-underline [role="tab"] {
+  position: relative;
   background: transparent !important;
   background-image: none !important;
   color: hsl(var(--muted-foreground));
   border-radius: 0 !important;
   box-shadow: none !important;
-  position: relative;
-}
-.tabs-underline [role="tab"]:hover { color: hsl(var(--foreground)); }
-.tabs-underline [role="tab"][data-state="active"] {
-  color: hsl(var(--foreground)) !important;
   font-weight: var(--font-medium);
+  transition: color 0.1s ease;
 }
+
+[role="tablist"]:not([data-variant="pill"]) > [role="tab"]:hover,
+.tabs-underline [role="tab"]:hover {
+  color: hsl(var(--foreground));
+}
+
+[role="tablist"]:not([data-variant="pill"]) > [role="tab"][data-state="active"],
+.tabs-underline [role="tab"][data-state="active"] {
+  color: hsl(var(--primary)) !important;
+  font-weight: var(--font-semibold);
+}
+
+/* The indicator is inset by the trigger's own horizontal padding so it tracks
+   the LABEL, not the hit area — a 2px rule running under the padding as well
+   reads as a stray divider between tabs. */
+[role="tablist"]:not([data-variant="pill"]) > [role="tab"][data-state="active"]::after,
 .tabs-underline [role="tab"][data-state="active"]::after {
   content: "";
   position: absolute;
-  left: 0.75rem; right: 0.75rem; bottom: -1px;
-  height: 2px; border-radius: 2px;
+  left: 0.75rem;
+  right: 0.75rem;
+  bottom: 0;
+  height: 2px;
   background: hsl(var(--primary));
 }
-.app-grain {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  opacity: 0.022;
-  mix-blend-mode: overlay;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+
+/* A VERTICAL tab rail (Finance's section nav) puts the indicator on the leading
+   edge instead — a horizontal rule under a stacked row is meaningless. */
+[role="tablist"][aria-orientation="vertical"] > [role="tab"][data-state="active"]::after {
+  left: 0;
+  right: auto;
+  top: 15%;
+  bottom: 15%;
+  width: 3px;
+  height: auto;
+  border-radius: 0 3px 3px 0;
 }
-html.light .app-grain { opacity: 0.03; }
 
 /* ──────────────────────────────────────────────────────────────────────────────
    Document surface — the public catalog page (/c/:slug).

--- a/src/modules/finance/components/OrderCustomsCard.tsx
+++ b/src/modules/finance/components/OrderCustomsCard.tsx
@@ -216,7 +216,7 @@ export const OrderCustomsCard: React.FC<{
                     disabled={savingId === l.id}
                     onChange={(code) => void saveLine(l.id, { taricCode: code })}
                     // Borderless and unfilled: the shared trigger/input chrome is a white
-                    // overlay (`bg-white/8` + `border-white/12`) built for the dark theme, and
+                    // overlay (`bg-surface-hover` + `border-hairline`) built for the dark theme, and
                     // on the cream card it stamps a white panel over the card. The hover tint
                     // carries the affordance instead. An unrecognised code still announces
                     // itself in the trigger's own content (red text + "not in the nomenclature"),

--- a/src/modules/payments-viva/components/VivaConfigCard.tsx
+++ b/src/modules/payments-viva/components/VivaConfigCard.tsx
@@ -219,7 +219,7 @@ export const VivaConfigCard: React.FC<Props> = ({ workspaceId }) => {
             <div className="space-y-1.5">
               <Label className="text-xs">Environment</Label>
               <select
-                className="w-full h-10 rounded-lg border border-white/12 bg-white/5 px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary/50 transition-all duration-200 hover:border-white/20"
+                className="w-full h-10 rounded-lg border border-hairline bg-white/5 px-3 text-sm text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary/50 transition-all duration-200 hover:border-white/20"
                 value={environment}
                 onChange={(e) => setEnvironment(e.target.value as VivaEnvironment)}
               >

--- a/src/modules/payments/components/InvoicingPanel.tsx
+++ b/src/modules/payments/components/InvoicingPanel.tsx
@@ -279,7 +279,7 @@ export const InvoicingPanel: React.FC<Props> = (_props) => {
             <code className="px-2 py-1 rounded bg-muted">{previewNumber}</code>
           </div>
 
-          <div className="grid grid-cols-2 gap-4 pt-2 border-t border-white/8">
+          <div className="grid grid-cols-2 gap-4 pt-2 border-t border-hairline">
             <div>
               <Label className="text-xs">Default payment terms (days)</Label>
               <Input

--- a/src/modules/payments/components/ProvidersPanel.tsx
+++ b/src/modules/payments/components/ProvidersPanel.tsx
@@ -61,7 +61,7 @@ export const ProvidersPanel: React.FC<Props> = (_props) => {
               </Button>
             </div>
           ) : (
-            <ul className="divide-y divide-white/8">
+            <ul className="divide-y divide-hairline">
               {providers.map(p => (
                 <li key={p.slug} className="py-3 flex items-center gap-3">
                   <CreditCard className="h-4 w-4 text-primary shrink-0" />

--- a/src/modules/projects/components/InviteCollaboratorsModal.tsx
+++ b/src/modules/projects/components/InviteCollaboratorsModal.tsx
@@ -175,7 +175,7 @@ export const InviteCollaboratorsModal: React.FC<InviteCollaboratorsModalProps> =
                 No collaborators yet. Send an invitation above.
               </div>
             ) : (
-              <ul className="divide-y divide-white/8 rounded-lg border border-border">
+              <ul className="divide-y divide-hairline rounded-lg border border-border">
                 {collaborators.map(c => (
                   <li key={c.id} className="p-3 flex items-center gap-3">
                     <Mail className="h-4 w-4 text-muted-foreground shrink-0" />

--- a/src/modules/projects/components/JobCostCard.tsx
+++ b/src/modules/projects/components/JobCostCard.tsx
@@ -73,7 +73,7 @@ export const JobCostCard: React.FC<{ projectId: string; reloadToken?: number }> 
 
   return (
     <Card className="dashboard-card">
-      <CardHeader className="border-b border-white/8 px-5 py-3">
+      <CardHeader className="border-b border-hairline px-5 py-3">
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
           <TrendingUp className="h-4 w-4 text-primary" /> Job cost
         </CardTitle>
@@ -103,7 +103,7 @@ export const JobCostCard: React.FC<{ projectId: string; reloadToken?: number }> 
         </div>
 
         {/* Cost breakdown — what makes up actual, plus the commitment still outstanding. */}
-        <div className="rounded-lg border border-white/8 divide-y divide-white/8 text-sm">
+        <div className="rounded-lg border border-hairline divide-y divide-hairline text-sm">
           <Row label="Supplier bills" value={money(pnl.supplier_cost, currency)} />
           <Row label="Labor" value={money(pnl.labor_cost, currency)}
             hint={pnl.labor.total_minutes > 0 ? `${hoursOf(pnl.labor.total_minutes)}h logged` : 'no time logged'} />
@@ -137,7 +137,7 @@ export const JobCostCard: React.FC<{ projectId: string; reloadToken?: number }> 
             <p className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground mb-2">
               <Clock className="h-3 w-3" /> Labor by person
             </p>
-            <div className="rounded-lg border border-white/8 divide-y divide-white/8 text-sm">
+            <div className="rounded-lg border border-hairline divide-y divide-hairline text-sm">
               {pnl.labor.by_user.map((u) => (
                 <div key={u.user_id ?? 'unassigned'} className="flex items-center gap-3 px-4 py-2">
                   <span className="min-w-0 flex-1 truncate">

--- a/src/modules/projects/components/ProjectExpensesCard.tsx
+++ b/src/modules/projects/components/ProjectExpensesCard.tsx
@@ -70,7 +70,7 @@ export const ProjectExpensesCard: React.FC<{
 
   return (
     <Card className="dashboard-card">
-      <CardHeader className="border-b border-white/8 px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
+      <CardHeader className="border-b border-hairline px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
         <div>
           <CardTitle className="flex items-center gap-2 text-sm font-medium">
             <Receipt className="h-4 w-4 text-primary" /> Expenses
@@ -97,7 +97,7 @@ export const ProjectExpensesCard: React.FC<{
             Nothing booked to this project yet.
           </p>
         ) : (
-          <div className="divide-y divide-white/8">
+          <div className="divide-y divide-hairline">
             {items.map((i) => (
               <div key={i.id} className="flex items-center gap-3 p-4">
                 <div className="w-20 shrink-0 text-xs text-muted-foreground">{i.expense_date}</div>
@@ -269,7 +269,7 @@ const LinkExpenseDialog: React.FC<{
             No unassigned expenses. Imported card spend appears here once it lands.
           </p>
         ) : (
-          <div className="max-h-80 overflow-auto rounded-md border border-white/10 divide-y divide-white/8">
+          <div className="max-h-80 overflow-auto rounded-md border border-white/10 divide-y divide-hairline">
             {candidates.map((c) => (
               <div key={c.id} className="flex items-center gap-2 p-3">
                 <div className="w-20 shrink-0 text-xs text-muted-foreground">{c.expense_date}</div>

--- a/src/modules/projects/components/tabs/BillingTab.tsx
+++ b/src/modules/projects/components/tabs/BillingTab.tsx
@@ -95,7 +95,7 @@ export const BillingTab: React.FC<{ projectId: string }> = ({ projectId }) => {
       )}
 
       {invoices.length > 0 && (
-        <Card className="dashboard-card"><CardContent className="p-0"><div className="divide-y divide-white/8">
+        <Card className="dashboard-card"><CardContent className="p-0"><div className="divide-y divide-hairline">
           {invoices.map((inv) => (
             <button key={inv.id} onClick={() => navigate(`/finance/invoices/${inv.id}`)} className="w-full text-left p-4 hover:bg-muted/40 transition-colors flex items-center gap-3">
               <FileText className="h-4 w-4 text-primary shrink-0" />

--- a/src/modules/projects/components/tabs/DocumentsTab.tsx
+++ b/src/modules/projects/components/tabs/DocumentsTab.tsx
@@ -71,7 +71,7 @@ export const DocumentsTab: React.FC<{ projectId: string; isOwner: boolean }> = (
 
   return (
     <Card className="dashboard-card">
-      <CardHeader className="border-b border-white/8 px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
+      <CardHeader className="border-b border-hairline px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
         <div>
           <CardTitle className="flex items-center gap-2 text-sm font-medium">
             <FileStack className="h-4 w-4 text-primary" /> Drawings &amp; documents
@@ -92,7 +92,7 @@ export const DocumentsTab: React.FC<{ projectId: string; isOwner: boolean }> = (
             No documents yet. Create one, then upload revisions against it.
           </p>
         ) : (
-          <div className="divide-y divide-white/8">
+          <div className="divide-y divide-hairline">
             {docs.map((d) => (
               <div key={d.id} className="p-4">
                 <div className="flex items-start gap-3">
@@ -116,7 +116,7 @@ export const DocumentsTab: React.FC<{ projectId: string; isOwner: boolean }> = (
                       </button>
                     )}
                     {expanded.has(d.id) && (
-                      <div className="mt-2 rounded-md border border-white/10 divide-y divide-white/8">
+                      <div className="mt-2 rounded-md border border-white/10 divide-y divide-hairline">
                         {d.revisions.filter((r) => !r.is_current).map((r) => (
                           <div key={r.id} className="flex items-center gap-2 px-3 py-1.5 text-sm">
                             <span className="w-14 shrink-0 text-xs text-muted-foreground">Rev {r.rev_label}</span>

--- a/src/modules/projects/components/tabs/FinanceTab.tsx
+++ b/src/modules/projects/components/tabs/FinanceTab.tsx
@@ -82,7 +82,7 @@ export const FinanceTab: React.FC<{ projectId: string; projectName?: string }> =
   }> = ({ title, icon, rows, total, due, kind }) => (
     <Card className="dashboard-card">
       <CardContent className="p-0">
-        <div className="flex items-center justify-between p-4 border-b border-white/8">
+        <div className="flex items-center justify-between p-4 border-b border-hairline">
           <div className="flex items-center gap-2">
             {icon}
             <h3 className="text-sm font-medium">{title}</h3>
@@ -100,7 +100,7 @@ export const FinanceTab: React.FC<{ projectId: string; projectName?: string }> =
         {rows.length === 0 ? (
           <div className="py-8 text-center text-sm text-muted-foreground">Nothing attached yet.</div>
         ) : (
-          <div className="divide-y divide-white/8">
+          <div className="divide-y divide-hairline">
             {rows.map((r) => (
               <div key={`${r.kind}-${r.id}`} className="p-4 flex items-center gap-3">
                 <FileText className="h-4 w-4 text-primary shrink-0" />
@@ -227,7 +227,7 @@ const AttachDialog: React.FC<{
             No unattached {direction === 'receivable' ? 'invoices / receivables for this client' : 'supplier bills / payables'} found.
           </p>
         ) : (
-          <div className="max-h-72 overflow-auto rounded-md border border-white/10 divide-y divide-white/8">
+          <div className="max-h-72 overflow-auto rounded-md border border-white/10 divide-y divide-hairline">
             {candidates.map((c, i) => (
               <React.Fragment key={`${c.kind}-${c.id}`}>
                 {/* Candidates for THIS project lead; everything else in the workspace sits behind a

--- a/src/modules/projects/components/tabs/OverviewTab.tsx
+++ b/src/modules/projects/components/tabs/OverviewTab.tsx
@@ -278,7 +278,7 @@ export const OverviewTab: React.FC<OverviewTabProps> = ({ project, isOwner = tru
               <Stat label="Blocked" value={taskStats.blocked} icon={<AlertTriangle className="h-3.5 w-3.5 text-amber-300" />} />
             </div>
             {upcomingTasks.length > 0 && (
-              <div className="pt-2 border-t border-white/8">
+              <div className="pt-2 border-t border-hairline">
                 <p className="text-xs text-muted-foreground mb-2">Next due</p>
                 <ul className="space-y-1.5">
                   {upcomingTasks.map(t => {

--- a/src/modules/projects/components/tabs/ProductsTab.tsx
+++ b/src/modules/projects/components/tabs/ProductsTab.tsx
@@ -165,7 +165,7 @@ export const ProductsTab: React.FC<{ projectId: string; workspaceId?: string | n
           <p className="text-xs text-muted-foreground mt-1">Add one manually, or import the lines from an attached quote.</p>
         </CardContent></Card>
       ) : (
-        <Card className="dashboard-card"><CardContent className="p-0"><div className="divide-y divide-white/8">
+        <Card className="dashboard-card"><CardContent className="p-0"><div className="divide-y divide-hairline">
           {rows.map((r) => (
             <div key={r.id} className="p-4 flex items-center gap-3 flex-wrap">
               <div className="flex-1 min-w-[180px]">
@@ -336,7 +336,7 @@ const AddProductDialog: React.FC<{
                 </div>
                 {searching && <p className="text-xs text-muted-foreground">Searching…</p>}
                 {results.length > 0 && (
-                  <div className="max-h-48 overflow-auto rounded-md border border-white/10 divide-y divide-white/8">
+                  <div className="max-h-48 overflow-auto rounded-md border border-white/10 divide-y divide-hairline">
                     {results.map(p => (
                       <button key={p.id} className="w-full text-left p-2 hover:bg-muted/40" onClick={() => { setPicked(p); setResults([]); setQuery(''); }}>
                         <p className="text-sm font-medium truncate">{p.name}</p>

--- a/src/modules/projects/components/tabs/PurchaseItemsTab.tsx
+++ b/src/modules/projects/components/tabs/PurchaseItemsTab.tsx
@@ -158,7 +158,7 @@ export const PurchaseItemsTab: React.FC<{ projectId: string; workspaceId?: strin
           <p className="text-xs text-muted-foreground mt-1">Add a door or window with its measurements — link a catalog product for a real photo, or generate one from the spec.</p>
         </CardContent></Card>
       ) : (
-        <Card className="dashboard-card"><CardContent className="p-0"><div className="divide-y divide-white/8">
+        <Card className="dashboard-card"><CardContent className="p-0"><div className="divide-y divide-hairline">
           {rows.map((it) => {
             const TypeIcon = TYPE_ICONS[it.item_type] || Package;
             return (
@@ -376,7 +376,7 @@ const PurchaseItemDialog: React.FC<{
             </div>
             {searching && <p className="text-xs text-muted-foreground">Searching…</p>}
             {results.length > 0 && (
-              <div className="max-h-40 overflow-auto rounded-md border border-white/10 divide-y divide-white/8">
+              <div className="max-h-40 overflow-auto rounded-md border border-white/10 divide-y divide-hairline">
                 {results.map(p => (
                   <button key={p.id} type="button" className="w-full text-left p-2 hover:bg-muted/40" onClick={() => pickProduct(p)}>
                     <p className="text-sm font-medium truncate">{p.name}</p>

--- a/src/modules/projects/components/tabs/QuotesTab.tsx
+++ b/src/modules/projects/components/tabs/QuotesTab.tsx
@@ -112,13 +112,13 @@ export const QuotesTab: React.FC<QuotesTabProps> = ({ projectId }) => {
         return (
           <Card key={chain.rootId} className="dashboard-card">
             {hasRevisions && (
-              <div className="px-4 py-2 border-b border-white/8 flex items-center gap-2 text-xs text-muted-foreground">
+              <div className="px-4 py-2 border-b border-hairline flex items-center gap-2 text-xs text-muted-foreground">
                 <GitBranch className="h-3.5 w-3.5" />
                 <span>Revision chain — {chain.revisions.length} versions</span>
               </div>
             )}
             <CardContent className="p-0">
-              <div className="divide-y divide-white/8">
+              <div className="divide-y divide-hairline">
                 {chain.revisions.map(q => (
                   <button
                     key={q.id}

--- a/src/modules/projects/components/tabs/RequestsTab.tsx
+++ b/src/modules/projects/components/tabs/RequestsTab.tsx
@@ -79,7 +79,7 @@ export const RequestsTab: React.FC<{ projectId: string; isOwner: boolean }> = ({
 
   return (
     <Card className="dashboard-card">
-      <CardHeader className="border-b border-white/8 px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
+      <CardHeader className="border-b border-hairline px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
         <div>
           <CardTitle className="flex items-center gap-2 text-sm font-medium">
             <MessageSquare className="h-4 w-4 text-primary" /> Requests
@@ -101,7 +101,7 @@ export const RequestsTab: React.FC<{ projectId: string; isOwner: boolean }> = ({
             {requests.length === 0 ? 'No requests yet.' : 'Nothing open — tick "Show closed" to see the rest.'}
           </p>
         ) : (
-          <div className="divide-y divide-white/8">
+          <div className="divide-y divide-hairline">
             {visible.map((r) => {
               const expanded = openId === r.id;
               return (

--- a/src/modules/projects/components/tabs/ScheduleTab.tsx
+++ b/src/modules/projects/components/tabs/ScheduleTab.tsx
@@ -159,7 +159,7 @@ export const ScheduleTab: React.FC<{ projectId: string; isOwner: boolean }> = ({
   return (
     <div className="space-y-4">
       <Card className="dashboard-card">
-        <CardHeader className="border-b border-white/8 px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
+        <CardHeader className="border-b border-hairline px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
           <div>
             <CardTitle className="flex items-center gap-2 text-sm font-medium">
               <GanttChartSquare className="h-4 w-4 text-primary" /> Schedule
@@ -182,8 +182,8 @@ export const ScheduleTab: React.FC<{ projectId: string; isOwner: boolean }> = ({
           ) : (
             <div className="flex">
               {/* Task names — fixed, so they stay readable while the timeline scrolls. */}
-              <div className="shrink-0 border-r border-white/8" style={{ width: 224 }}>
-                <div className="h-8 border-b border-white/8" />
+              <div className="shrink-0 border-r border-hairline" style={{ width: 224 }}>
+                <div className="h-8 border-b border-hairline" />
                 {tasks.map((t) => (
                   <button
                     key={t.id}
@@ -203,9 +203,9 @@ export const ScheduleTab: React.FC<{ projectId: string; isOwner: boolean }> = ({
               <div className="min-w-0 flex-1 overflow-x-auto" ref={timelineRef}>
                 <div className="relative" style={{ width: timelineWidth }}>
                   {/* month header */}
-                  <div className="relative h-8 border-b border-white/8">
+                  <div className="relative h-8 border-b border-hairline">
                     {monthTicks.map((m) => (
-                      <div key={m.label + m.left} className="absolute top-0 h-full border-l border-white/8 pl-1 text-[10px] leading-8 text-muted-foreground" style={{ left: m.left }}>
+                      <div key={m.label + m.left} className="absolute top-0 h-full border-l border-hairline pl-1 text-[10px] leading-8 text-muted-foreground" style={{ left: m.left }}>
                         {m.label}
                       </div>
                     ))}
@@ -436,7 +436,7 @@ const ScheduleEditDialog: React.FC<{
           <div className="space-y-1">
             <Label className="text-xs flex items-center gap-1"><Link2 className="h-3 w-3" /> Runs after</Label>
             {myDeps.length > 0 && (
-              <div className="rounded-md border border-white/10 divide-y divide-white/8 mb-2">
+              <div className="rounded-md border border-white/10 divide-y divide-hairline mb-2">
                 {myDeps.map((d) => (
                   <div key={d.id} className="flex items-center gap-2 px-3 py-1.5 text-sm">
                     <span className="min-w-0 flex-1 truncate">{titleById.get(d.predecessor_id) ?? 'Unknown task'}</span>

--- a/src/modules/projects/components/tabs/SheetsTab.tsx
+++ b/src/modules/projects/components/tabs/SheetsTab.tsx
@@ -211,7 +211,7 @@ export const SheetsTab: React.FC<SheetsTabProps> = ({ projectId, isOwner = true 
 
       {projectOwned.length > 0 && (
         <Card className="dashboard-card">
-          <div className="px-4 py-2 border-b border-white/8 flex items-center gap-2">
+          <div className="px-4 py-2 border-b border-hairline flex items-center gap-2">
             <Ruler className="h-3.5 w-3.5 text-primary" />
             <span className="text-sm font-medium">Technical plans</span>
             <span className="text-xs text-muted-foreground ml-auto">
@@ -219,7 +219,7 @@ export const SheetsTab: React.FC<SheetsTabProps> = ({ projectId, isOwner = true 
             </span>
           </div>
           <CardContent className="p-0">
-            <ul className="divide-y divide-white/8">
+            <ul className="divide-y divide-hairline">
               {projectOwned.map(s => <SheetRow key={s.id} s={s} />)}
             </ul>
           </CardContent>
@@ -228,7 +228,7 @@ export const SheetsTab: React.FC<SheetsTabProps> = ({ projectId, isOwner = true 
 
       {grouped.map(g => (
         <Card key={g.moodboard_id} className="dashboard-card">
-          <div className="px-4 py-2 border-b border-white/8 flex items-center gap-2">
+          <div className="px-4 py-2 border-b border-hairline flex items-center gap-2">
             <Palette className="h-3.5 w-3.5 text-primary" />
             <button
               type="button"
@@ -240,7 +240,7 @@ export const SheetsTab: React.FC<SheetsTabProps> = ({ projectId, isOwner = true 
             <span className="text-xs text-muted-foreground ml-auto">{g.sheets.length} {g.sheets.length === 1 ? 'sheet' : 'sheets'}</span>
           </div>
           <CardContent className="p-0">
-            <ul className="divide-y divide-white/8">
+            <ul className="divide-y divide-hairline">
               {g.sheets.map(s => <SheetRow key={s.id} s={s} />)}
             </ul>
           </CardContent>

--- a/src/modules/projects/components/tabs/SiteTab.tsx
+++ b/src/modules/projects/components/tabs/SiteTab.tsx
@@ -161,7 +161,7 @@ const SnagsView: React.FC<{ projectId: string; isOwner: boolean }> = ({ projectI
 
   return (
     <Card className="dashboard-card">
-      <CardHeader className="border-b border-white/8 px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
+      <CardHeader className="border-b border-hairline px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
         <div>
           <CardTitle className="flex items-center gap-2 text-sm font-medium">
             <ClipboardList className="h-4 w-4 text-primary" /> Snags
@@ -194,7 +194,7 @@ const SnagsView: React.FC<{ projectId: string; isOwner: boolean }> = ({ projectI
             {snags.length === 0 ? 'No snags raised.' : 'Nothing matches the filter.'}
           </p>
         ) : (
-          <div className="divide-y divide-white/8">
+          <div className="divide-y divide-hairline">
             {visible.map((s) => (
               <div key={s.id} className="p-4">
                 <div className="flex items-start gap-3">
@@ -373,7 +373,7 @@ const SiteLogView: React.FC<{ projectId: string; isOwner: boolean }> = ({ projec
 
   return (
     <Card className="dashboard-card">
-      <CardHeader className="border-b border-white/8 px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
+      <CardHeader className="border-b border-hairline px-5 py-3 flex-row items-center justify-between space-y-0 gap-3 flex-wrap">
         <div>
           <CardTitle className="flex items-center gap-2 text-sm font-medium">
             <CalendarDays className="h-4 w-4 text-primary" /> Site log
@@ -390,7 +390,7 @@ const SiteLogView: React.FC<{ projectId: string; isOwner: boolean }> = ({ projec
         {logs.length === 0 ? (
           <p className="py-12 text-center text-sm text-muted-foreground">No site visits logged yet.</p>
         ) : (
-          <div className="divide-y divide-white/8">
+          <div className="divide-y divide-hairline">
             {logs.map((l) => (
               <div key={l.id} className="p-4">
                 <div className="flex items-start gap-3">

--- a/src/modules/projects/components/tabs/TasksTab.tsx
+++ b/src/modules/projects/components/tabs/TasksTab.tsx
@@ -221,7 +221,7 @@ export const TasksTab: React.FC<TasksTabProps> = ({ projectId, isOwner = true })
       ) : (
         <Card className="dashboard-card">
           <CardContent className="p-0">
-            <ul className="divide-y divide-white/8">
+            <ul className="divide-y divide-hairline">
               {tasks.map(parent => (
                 <TaskRow
                   key={parent.id}

--- a/src/modules/projects/components/tabs/TimelineTab.tsx
+++ b/src/modules/projects/components/tabs/TimelineTab.tsx
@@ -137,7 +137,7 @@ export const TimelineTab: React.FC<TimelineTabProps> = ({ projectId }) => {
       ) : (
         <Card className="dashboard-card">
           <CardContent className="p-0">
-            <ul className="divide-y divide-white/8">
+            <ul className="divide-y divide-hairline">
               {visible.map(e => (
                 <li key={e.id} className="p-3 sm:p-4 flex items-start gap-3 hover:bg-muted/40 transition-colors">
                   <div className="mt-0.5 shrink-0">

--- a/src/pages/DesignSystemPage.tsx
+++ b/src/pages/DesignSystemPage.tsx
@@ -1,0 +1,798 @@
+import React from 'react';
+import {
+  Building2,
+  Calendar,
+  CheckCircle2,
+  Download,
+  FileText,
+  Filter,
+  Mail,
+  Palette,
+  Phone,
+  Plus,
+  StickyNote,
+  Upload,
+  Users,
+} from 'lucide-react';
+
+import { PageHeader } from '@/components/shared/PageHeader';
+import { SectionHeader } from '@/components/shared/SectionHeader';
+import { Button } from '@/components/core/ui/button';
+import { Badge } from '@/components/core/ui/badge';
+import { Input } from '@/components/core/ui/input';
+import { Textarea } from '@/components/core/ui/textarea';
+import { Checkbox } from '@/components/core/ui/checkbox';
+import { Switch } from '@/components/core/ui/switch';
+import { Label } from '@/components/core/ui/label';
+import { Progress } from '@/components/core/ui/progress';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/core/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/core/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/core/ui/tabs';
+import {
+  HubCellEmpty,
+  HubCellLink,
+  HubDataTable,
+  HubEmptyState,
+  HubFilterSelect,
+  HubPanel,
+  HubPanelAddAction,
+  HubProperty,
+  HubPropertyList,
+  HubRecordIdentity,
+  HubRecordLayout,
+  HubSideNav,
+  HubStatGrid,
+  HubStatTile,
+  HubTabAddAction,
+  HubTabNav,
+  HubTimeline,
+  HubTimelineGroup,
+  HubTimelineItem,
+  HubToolbar,
+} from '@/components/core/hub';
+import type { HubColumn, HubSort } from '@/components/core/hub';
+import { useTheme } from '@/contexts/ThemeContext';
+import { formatMoney } from '@/utils/decimal';
+
+/**
+ * SPECIMEN SHEET — every surface of the design system on one page.
+ *
+ * This is a working page, not a screenshot: it renders the real components with
+ * the real tokens, so it changes the moment the system does. That is the point —
+ * a design system documented only in prose drifts from the code within a
+ * release, and then the prose is worse than nothing because people trust it.
+ *
+ * The theme/accent switcher at the top is here rather than buried in settings
+ * because the one thing you cannot check from a screenshot is whether a surface
+ * survives all four combinations (light/dark × green/blue).
+ */
+
+interface DemoRow {
+  id: string;
+  name: string;
+  company: string | null;
+  stage: string;
+  owner: string | null;
+  value: number;
+  updated: string;
+}
+
+const DEMO_ROWS: DemoRow[] = [
+  { id: '1', name: 'Elena Papadopoulou', company: 'Aegean Interiors', stage: 'Qualified', owner: 'Nikos R.', value: 18400, updated: '2 hours ago' },
+  { id: '2', name: 'Marcus Lindqvist', company: 'Nord Studio', stage: 'Proposal', owner: 'Anna K.', value: 42750, updated: 'Yesterday' },
+  { id: '3', name: 'Sofia Marino', company: null, stage: 'New', owner: null, value: 0, updated: '3 days ago' },
+  { id: '4', name: 'Yusuf Demir', company: 'Levant Stone', stage: 'Won', owner: 'Nikos R.', value: 96200, updated: 'Last week' },
+  { id: '5', name: 'Claire Dubois', company: 'Atelier Sud', stage: 'Lost', owner: 'Anna K.', value: 7300, updated: 'Last week' },
+];
+
+const STAGE_VARIANT: Record<string, 'success' | 'info' | 'warning' | 'error' | 'neutral'> = {
+  Won: 'success',
+  Proposal: 'info',
+  Qualified: 'warning',
+  Lost: 'error',
+  New: 'neutral',
+};
+
+// Even a specimen sheet formats money through the one canonical formatter —
+// tests/unit/moneyPrimitives.test.ts fails the build on a local re-implementation,
+// and it is right to: a second formatter is how a platform ends up showing two
+// different renderings of the same figure on two screens.
+const demoMoney = (n: number) =>
+  n === 0 ? null : formatMoney(n, 'EUR', { decimals: 0, maxDecimals: 0 });
+
+export default function DesignSystemPage() {
+  const { theme, setTheme, accent, setAccent } = useTheme();
+
+  const [search, setSearch] = React.useState('');
+  const [stage, setStage] = React.useState('all');
+  const [owner, setOwner] = React.useState('all');
+  const [selected, setSelected] = React.useState<Set<string>>(new Set(['2']));
+  const [sort, setSort] = React.useState<HubSort>({ columnId: 'value', direction: 'desc' });
+  const [section, setSection] = React.useState('overview');
+  const [navItem, setNavItem] = React.useState('account');
+
+  const rows = React.useMemo(() => {
+    const filtered = DEMO_ROWS.filter(
+      (r) =>
+        (stage === 'all' || r.stage === stage) &&
+        (owner === 'all' || r.owner === owner) &&
+        (search === '' || `${r.name} ${r.company ?? ''}`.toLowerCase().includes(search.toLowerCase())),
+    );
+    const dir = sort.direction === 'asc' ? 1 : -1;
+    return [...filtered].sort((a, b) => {
+      if (sort.columnId === 'value') return (a.value - b.value) * dir;
+      if (sort.columnId === 'name') return a.name.localeCompare(b.name) * dir;
+      return 0;
+    });
+  }, [search, stage, owner, sort]);
+
+  const columns: HubColumn<DemoRow>[] = [
+    { id: 'name', header: 'Name', sortable: true, cell: (r) => <HubCellLink>{r.name}</HubCellLink> },
+    {
+      id: 'company',
+      header: 'Company',
+      hideBelow: 'md',
+      cell: (r) => r.company ?? <HubCellEmpty />,
+    },
+    {
+      id: 'stage',
+      header: 'Stage',
+      cell: (r) => <Badge variant={STAGE_VARIANT[r.stage] ?? 'neutral'}>{r.stage}</Badge>,
+    },
+    { id: 'owner', header: 'Owner', hideBelow: 'lg', cell: (r) => r.owner ?? <HubCellEmpty /> },
+    {
+      id: 'value',
+      header: 'Value',
+      align: 'right',
+      sortable: true,
+      cell: (r) => demoMoney(r.value) ?? <HubCellEmpty />,
+    },
+    { id: 'updated', header: 'Last activity', align: 'right', hideBelow: 'sm', cell: (r) => r.updated },
+  ];
+
+  const activeFilters = [stage, owner].filter((v) => v !== 'all').length;
+
+  return (
+    <>
+      <PageHeader
+        icon={Palette}
+        title="Design system"
+        subtitle="Every surface, token and pattern — rendered live, in the current theme"
+        breadcrumbs={[{ label: 'Platform', to: '/' }, { label: 'Design system' }]}
+        actions={
+          <>
+            <Button variant="outline" size="sm">
+              <Download />
+              Export tokens
+            </Button>
+            <Button size="sm">
+              <Plus />
+              New component
+            </Button>
+          </>
+        }
+      >
+        <HubTabNav
+          aria-label="Design system sections"
+          activeId={section}
+          onSelect={setSection}
+          items={[
+            { id: 'overview', label: 'Foundations' },
+            { id: 'list', label: 'List screen' },
+            { id: 'record', label: 'Record screen' },
+            { id: 'forms', label: 'Forms' },
+          ]}
+          trailing={<HubTabAddAction label="Add view" />}
+        />
+      </PageHeader>
+
+      <div className="space-y-6 p-4 sm:p-6">
+        {/* ── Theme matrix ─────────────────────────────────────────────── */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Theme</CardTitle>
+            <CardDescription>
+              Two modes × two accents. Every surface below has to hold up in all four — check them
+              here rather than trusting a screenshot of one.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center gap-4">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold text-muted-foreground">Mode</span>
+              <div className="flex gap-1">
+                {(['light', 'dark'] as const).map((t) => (
+                  <Button
+                    key={t}
+                    size="sm"
+                    variant={theme === t ? 'default' : 'outline'}
+                    onClick={() => setTheme(t)}
+                  >
+                    {t}
+                  </Button>
+                ))}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold text-muted-foreground">Accent</span>
+              <div className="flex gap-1">
+                {(['green', 'blue'] as const).map((a) => (
+                  <Button
+                    key={a}
+                    size="sm"
+                    variant={accent === a ? 'default' : 'outline'}
+                    onClick={() => setAccent(a)}
+                  >
+                    {a}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {section === 'overview' && (
+          <>
+            <section>
+              <SectionHeader
+                title="Surfaces"
+                subtitle="Page → panel → sunken. Three steps, hairline-separated, no glass and no shadow at rest."
+              />
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-md border border-hairline bg-background p-4">
+                  <p className="text-xs font-semibold text-muted-foreground">Page</p>
+                  <p className="mt-1 text-sm">--background</p>
+                </div>
+                <div className="rounded-md border border-hairline bg-card p-4">
+                  <p className="text-xs font-semibold text-muted-foreground">Panel</p>
+                  <p className="mt-1 text-sm">--card</p>
+                </div>
+                <div className="rounded-md border border-hairline bg-surface-sunken p-4">
+                  <p className="text-xs font-semibold text-muted-foreground">Sunken</p>
+                  <p className="mt-1 text-sm">--surface-sunken</p>
+                </div>
+              </div>
+            </section>
+
+            <section>
+              <SectionHeader
+                title="Type scale"
+                subtitle="Serif for identity (h1/h2), sans for chrome (h3 and below). Weight carries the hierarchy."
+              />
+              <Card>
+                <CardContent className="space-y-2">
+                  <h1 className="text-xl font-semibold">Page title — 20px display serif</h1>
+                  <h2 className="text-base font-semibold">Section — 16px sans semibold</h2>
+                  <h3 className="text-sm font-semibold">Panel title — 14px sans semibold</h3>
+                  <p className="text-sm">Body — 14px regular, the default for all content.</p>
+                  <p className="text-xs text-muted-foreground">
+                    Caption / label — 12px, muted. Used for property labels and helper text.
+                  </p>
+                  <p className="text-[11px] font-semibold text-muted-foreground">
+                    Table header — 11px semibold, muted, never uppercase.
+                  </p>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section>
+              <SectionHeader
+                title="Buttons"
+                subtitle="One solid button per screen. Everything else outlines or goes ghost."
+              />
+              <Card>
+                <CardContent className="flex flex-wrap items-center gap-2">
+                  <Button>Primary</Button>
+                  <Button variant="secondary">Secondary</Button>
+                  <Button variant="outline">Outline</Button>
+                  <Button variant="ghost">Ghost</Button>
+                  <Button variant="destructive">Delete</Button>
+                  <Button variant="link">Link</Button>
+                  <Button size="sm" variant="outline">
+                    <Upload />
+                    Small
+                  </Button>
+                  <Button size="icon" variant="outline" aria-label="Add">
+                    <Plus />
+                  </Button>
+                  <Button disabled>Disabled</Button>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section>
+              <SectionHeader
+                title="Tags"
+                subtitle="Tinted, squared, 11px. A status is a label — it must not carry the weight of a button."
+              />
+              <Card>
+                <CardContent className="flex flex-wrap items-center gap-2">
+                  <Badge>Default</Badge>
+                  <Badge variant="secondary">Secondary</Badge>
+                  <Badge variant="outline">Outline</Badge>
+                  <Badge variant="success">Paid</Badge>
+                  <Badge variant="warning">Pending</Badge>
+                  <Badge variant="error">Overdue</Badge>
+                  <Badge variant="info">Draft</Badge>
+                  <Badge variant="neutral">Archived</Badge>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section>
+              <SectionHeader
+                title="KPI tiles"
+                subtitle="Auto-fitting grid. Deltas are coloured by meaning, not by direction."
+              />
+              <HubStatGrid>
+                <HubStatTile label="Contacts created" value="444" category="OFFLINE SOURCE" delta={{ value: '12.4%', direction: 'up', caption: 'vs last month' }} />
+                <HubStatTile label="Qualified leads" value="69" delta={{ value: '43.75%', direction: 'up' }} help="Contacts whose lifecycle stage reached MQL in the period." />
+                <HubStatTile label="Cost per lead" value="€38.20" delta={{ value: '9.1%', direction: 'up', upIsGood: false, caption: 'vs last month' }} />
+                <HubStatTile label="Landing page views" value="428,376" delta={{ value: '2.78%', direction: 'down', caption: 'vs last month' }} />
+                <HubStatTile label="Open deals" value="1,124" delta={{ value: '0.0%', direction: 'flat' }} />
+              </HubStatGrid>
+            </section>
+
+            <section>
+              <SectionHeader title="Tabs" subtitle="Underline, platform-wide. A filled pill is a button; a tab is a place." />
+              <Card>
+                <CardContent>
+                  <Tabs defaultValue="activity">
+                    <TabsList>
+                      <TabsTrigger value="activity">Activity</TabsTrigger>
+                      <TabsTrigger value="notes">Notes</TabsTrigger>
+                      <TabsTrigger value="emails">Emails</TabsTrigger>
+                      <TabsTrigger value="calls">Calls</TabsTrigger>
+                      <TabsTrigger value="tasks">Tasks</TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="activity" className="text-sm text-muted-foreground">
+                      The active tab is marked by a 2px accent rule under its label and an accent
+                      text colour — location, not action.
+                    </TabsContent>
+                    <TabsContent value="notes" className="text-sm text-muted-foreground">
+                      Notes panel.
+                    </TabsContent>
+                    <TabsContent value="emails" className="text-sm text-muted-foreground">
+                      Emails panel.
+                    </TabsContent>
+                    <TabsContent value="calls" className="text-sm text-muted-foreground">
+                      Calls panel.
+                    </TabsContent>
+                    <TabsContent value="tasks" className="text-sm text-muted-foreground">
+                      Tasks panel.
+                    </TabsContent>
+                  </Tabs>
+                </CardContent>
+              </Card>
+            </section>
+
+            <section>
+              <SectionHeader title="Empty states" subtitle="Two kinds of nothing, two different answers." />
+              <div className="grid gap-3 md:grid-cols-2">
+                <Card>
+                  <HubEmptyState
+                    icon={Users}
+                    title="No contacts yet"
+                    description="Import a list or create your first contact to get started."
+                    action={
+                      <>
+                        <Button size="sm">
+                          <Plus />
+                          Create contact
+                        </Button>
+                        <Button size="sm" variant="outline">
+                          <Upload />
+                          Import
+                        </Button>
+                      </>
+                    }
+                  />
+                </Card>
+                <Card>
+                  <HubEmptyState
+                    variant="filtered"
+                    icon={Filter}
+                    title="No contacts match these filters"
+                    description="You have 4,182 contacts — three filters are excluding all of them."
+                    action={
+                      <Button size="sm" variant="outline">
+                        Clear filters
+                      </Button>
+                    }
+                  />
+                </Card>
+              </div>
+            </section>
+          </>
+        )}
+
+        {section === 'list' && (
+          <section>
+            <SectionHeader
+              title="List screen"
+              subtitle="Toolbar, filters, selection, sorting, empty and footer — one object, not three stacked cards."
+            />
+            <div className="overflow-hidden rounded-md border border-hairline bg-card">
+              <HubToolbar
+                search={search}
+                onSearchChange={setSearch}
+                searchPlaceholder="Search name, company"
+                filters={
+                  <>
+                    <HubFilterSelect
+                      label="Stage"
+                      value={stage}
+                      onChange={setStage}
+                      options={[
+                        { value: 'all', label: 'All stages' },
+                        { value: 'New', label: 'New' },
+                        { value: 'Qualified', label: 'Qualified' },
+                        { value: 'Proposal', label: 'Proposal' },
+                        { value: 'Won', label: 'Won' },
+                        { value: 'Lost', label: 'Lost' },
+                      ]}
+                    />
+                    <HubFilterSelect
+                      label="Owner"
+                      value={owner}
+                      onChange={setOwner}
+                      options={[
+                        { value: 'all', label: 'Any owner' },
+                        { value: 'Nikos R.', label: 'Nikos R.' },
+                        { value: 'Anna K.', label: 'Anna K.' },
+                      ]}
+                    />
+                    {activeFilters > 0 && (
+                      <Button
+                        variant="link"
+                        size="sm"
+                        className="h-8 text-xs"
+                        onClick={() => {
+                          setStage('all');
+                          setOwner('all');
+                        }}
+                      >
+                        Clear {activeFilters} filter{activeFilters === 1 ? '' : 's'}
+                      </Button>
+                    )}
+                  </>
+                }
+                actions={
+                  <>
+                    <Button size="sm" variant="outline">
+                      <Download />
+                      Export
+                    </Button>
+                    <Button size="sm">
+                      <Plus />
+                      Create
+                    </Button>
+                  </>
+                }
+              />
+              <HubDataTable
+                rows={rows}
+                columns={columns}
+                rowId={(r) => r.id}
+                selected={selected}
+                onSelectedChange={setSelected}
+                sort={sort}
+                onSortChange={setSort}
+                className="rounded-none border-0"
+                empty={
+                  <HubEmptyState
+                    variant="filtered"
+                    icon={Filter}
+                    title="Nothing matches"
+                    description="Widen the search or clear a filter."
+                  />
+                }
+                footer={
+                  <>
+                    <span>
+                      {selected.size > 0
+                        ? `${selected.size} selected`
+                        : `Showing ${rows.length} of ${DEMO_ROWS.length}`}
+                    </span>
+                    {selected.size > 0 && (
+                      <div className="ml-auto flex gap-1.5">
+                        <Button size="sm" variant="outline">
+                          Assign owner
+                        </Button>
+                        <Button size="sm" variant="outline">
+                          Add to list
+                        </Button>
+                      </div>
+                    )}
+                  </>
+                }
+              />
+            </div>
+          </section>
+        )}
+
+        {section === 'record' && (
+          <section>
+            <SectionHeader
+              title="Record screen"
+              subtitle="Left: who. Centre: what happened. Right: what it is connected to."
+            />
+            <div className="overflow-hidden rounded-md border border-hairline bg-background">
+              <HubRecordLayout
+                left={
+                  <>
+                    <HubRecordIdentity
+                      name="Elena Papadopoulou"
+                      subtitle="Specification Manager"
+                      meta={<Badge variant="info">Qualified lead</Badge>}
+                      actions={
+                        <>
+                          <Button size="icon-sm" variant="outline" aria-label="Log a note">
+                            <StickyNote />
+                          </Button>
+                          <Button size="icon-sm" variant="outline" aria-label="Send email">
+                            <Mail />
+                          </Button>
+                          <Button size="icon-sm" variant="outline" aria-label="Log a call">
+                            <Phone />
+                          </Button>
+                          <Button size="icon-sm" variant="outline" aria-label="Create task">
+                            <CheckCircle2 />
+                          </Button>
+                          <Button size="icon-sm" variant="outline" aria-label="Schedule meeting">
+                            <Calendar />
+                          </Button>
+                        </>
+                      }
+                    />
+                    <HubPanel title="About this contact" collapsible>
+                      <HubPropertyList>
+                        <HubProperty label="First name">Elena</HubProperty>
+                        <HubProperty label="Last name">Papadopoulou</HubProperty>
+                        <HubProperty label="Email">
+                          <a className="text-primary hover:underline" href="mailto:elena@aegean.gr">
+                            elena@aegean.gr
+                          </a>
+                        </HubProperty>
+                        <HubProperty label="Phone">+30 210 555 0117</HubProperty>
+                        <HubProperty label="VAT number">{null}</HubProperty>
+                        <HubProperty label="Created">28 Feb 2026, 11:11</HubProperty>
+                      </HubPropertyList>
+                    </HubPanel>
+                  </>
+                }
+                right={
+                  <>
+                    <HubPanel title="Deals (2)" action={<HubPanelAddAction label="Add deal" />}>
+                      <div className="space-y-2">
+                        {[
+                          { title: '€18,400 — Showroom refit', stage: 'Proposal sent', close: '30 Nov 2026' },
+                          { title: '€4,200 — Sample programme', stage: 'Closed won', close: '30 Nov 2025' },
+                        ].map((d) => (
+                          <div key={d.title} className="rounded-sm border border-hairline p-2.5">
+                            <p className="text-sm font-semibold text-primary">{d.title}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">Stage: {d.stage}</p>
+                            <p className="text-xs text-muted-foreground">Close date: {d.close}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </HubPanel>
+                    <HubPanel title="Company (1)" action={<HubPanelAddAction label="Add" />}>
+                      <div className="flex items-center gap-2 text-sm">
+                        <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        <span className="font-semibold text-primary">Aegean Interiors</span>
+                      </div>
+                    </HubPanel>
+                    <HubPanel title="Attachments (0)" action={<HubPanelAddAction label="Upload" />}>
+                      <p className="text-xs text-muted-foreground">Nothing attached yet.</p>
+                    </HubPanel>
+                  </>
+                }
+              >
+                <div className="rounded-md border border-hairline bg-card">
+                  <HubTabNav
+                    aria-label="Record sections"
+                    activeId="activity"
+                    onSelect={() => undefined}
+                    items={[
+                      { id: 'activity', label: 'Activity' },
+                      { id: 'notes', label: 'Notes', count: 4 },
+                      { id: 'emails', label: 'Emails', count: 12 },
+                      { id: 'calls', label: 'Calls' },
+                      { id: 'tasks', label: 'Tasks', count: 2 },
+                    ]}
+                  />
+                  <div className="p-3">
+                    <HubTimeline>
+                      <HubTimelineGroup label="Pinned">
+                        <HubTimelineItem
+                          pinned
+                          expandable
+                          defaultExpanded
+                          title={
+                            <>
+                              <strong className="font-semibold">Note</strong> from Nikos R.
+                            </>
+                          }
+                          timestamp="9 Mar, 11:41"
+                        >
+                          Asked for the full technical sheet on the porcelain range before the
+                          specification meeting. Sent the EN 14411 declaration.
+                        </HubTimelineItem>
+                      </HubTimelineGroup>
+
+                      <HubTimelineGroup label="Upcoming">
+                        <HubTimelineItem
+                          icon={CheckCircle2}
+                          title={
+                            <>
+                              <strong className="font-semibold">Task</strong> assigned to Anna K. —
+                              send sample box
+                            </>
+                          }
+                          timestamp="Overdue: 8 Mar"
+                          overdue
+                        />
+                        <HubTimelineItem
+                          icon={Calendar}
+                          title={
+                            <>
+                              <strong className="font-semibold">Meeting</strong> — specification
+                              review
+                            </>
+                          }
+                          timestamp="4 May, 13:30"
+                        />
+                      </HubTimelineGroup>
+
+                      <HubTimelineGroup label="March 2026">
+                        <HubTimelineItem
+                          icon={Mail}
+                          expandable
+                          title={
+                            <>
+                              <strong className="font-semibold">Email</strong> — Re: Aegean showroom
+                              quantities
+                            </>
+                          }
+                          timestamp="9 Mar, 14:11"
+                        >
+                          Confirmed 340 m² of the matte finish and asked whether the trim profiles
+                          ship from the same batch.
+                        </HubTimelineItem>
+                        <HubTimelineItem
+                          icon={FileText}
+                          title={
+                            <>
+                              <strong className="font-semibold">Quote</strong> QT-2026-0184 sent
+                            </>
+                          }
+                          timestamp="2 Mar, 09:02"
+                        />
+                      </HubTimelineGroup>
+                    </HubTimeline>
+                  </div>
+                </div>
+              </HubRecordLayout>
+            </div>
+          </section>
+        )}
+
+        {section === 'forms' && (
+          <section className="space-y-6">
+            <SectionHeader
+              title="Settings screen"
+              subtitle="A section rail plus one form panel. Every control is the same 36px height."
+            />
+            <div className="flex flex-col gap-4 lg:flex-row">
+              <HubSideNav
+                activeId={navItem}
+                onSelect={setNavItem}
+                aria-label="Settings sections"
+                groups={[
+                  {
+                    label: 'Your preferences',
+                    items: [
+                      { id: 'account', label: 'Account defaults' },
+                      { id: 'notifications', label: 'Notifications', count: 3 },
+                      { id: 'security', label: 'Security' },
+                    ],
+                  },
+                  {
+                    label: 'Workspace',
+                    items: [
+                      { id: 'team', label: 'Users & teams' },
+                      { id: 'branding', label: 'Branding' },
+                      { id: 'integrations', label: 'Integrations' },
+                      { id: 'billing', label: 'Billing' },
+                    ],
+                  },
+                ]}
+              />
+
+              <div className="min-w-0 flex-1">
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Account defaults</CardTitle>
+                    <CardDescription>
+                      Applied to every new record created in this workspace.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="ds-name">Workspace name</Label>
+                        <Input id="ds-name" defaultValue="Aegean Interiors" />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="ds-currency">Default currency</Label>
+                        <Select defaultValue="eur">
+                          <SelectTrigger id="ds-currency">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="eur">EUR — Euro</SelectItem>
+                            <SelectItem value="gbp">GBP — Pound sterling</SelectItem>
+                            <SelectItem value="usd">USD — US dollar</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <Label htmlFor="ds-notes">Default quote footer</Label>
+                      <Textarea
+                        id="ds-notes"
+                        rows={3}
+                        defaultValue="Prices exclude VAT. Lead time confirmed on order."
+                      />
+                    </div>
+
+                    <div className="space-y-2.5 border-t border-hairline pt-4">
+                      <div className="flex items-center gap-2.5">
+                        <Checkbox id="ds-cb" defaultChecked />
+                        <Label htmlFor="ds-cb" className="font-normal">
+                          Send me a weekly pipeline digest
+                        </Label>
+                      </div>
+                      <div className="flex items-center justify-between gap-3">
+                        <Label htmlFor="ds-sw" className="font-normal">
+                          Require approval before a quote is sent
+                        </Label>
+                        <Switch id="ds-sw" defaultChecked />
+                      </div>
+                    </div>
+
+                    <div className="space-y-1.5 border-t border-hairline pt-4">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="font-semibold text-muted-foreground">Storage used</span>
+                        <span className="tabular-nums text-muted-foreground">62%</span>
+                      </div>
+                      <Progress value={62} />
+                    </div>
+                  </CardContent>
+                  <CardFooter className="justify-end">
+                    <Button variant="outline">Cancel</Button>
+                    <Button>Save changes</Button>
+                  </CardFooter>
+                </Card>
+              </div>
+            </div>
+          </section>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/pages/DiscoverPage.tsx
+++ b/src/pages/DiscoverPage.tsx
@@ -342,7 +342,7 @@ function FactoryModal({
           style={{ background: 'var(--brand-gradient)' }}
         >
           <div className="absolute -top-12 -left-12 w-72 h-72 rounded-full bg-white/10 blur-3xl pointer-events-none" />
-          <div className="absolute -bottom-10 right-1/3 w-80 h-80 rounded-full bg-white/8 blur-3xl pointer-events-none" />
+          <div className="absolute -bottom-10 right-1/3 w-80 h-80 rounded-full bg-surface-hover blur-3xl pointer-events-none" />
 
           {/* Top-right controls */}
           {/* `hideClose` on the DialogContent means this is the ONLY way out on

--- a/src/pages/PublicAccountStatementPage.tsx
+++ b/src/pages/PublicAccountStatementPage.tsx
@@ -101,7 +101,7 @@ const PublicAccountStatementPage: React.FC = () => {
             className="rounded-lg border bg-card shadow-sm overflow-hidden"
             style={data.background_url ? { backgroundImage: `url(${data.background_url})`, backgroundSize: 'cover', backgroundPosition: 'top center' } : undefined}
           >
-            <div className="bg-card/92 p-5 sm:p-8 space-y-5">
+            <div className="bg-card/90 p-5 sm:p-8 space-y-5">
               {/* Header: logo + title + period + download */}
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="space-y-2">

--- a/src/pages/PublicClientViewPage.tsx
+++ b/src/pages/PublicClientViewPage.tsx
@@ -351,7 +351,7 @@ export default function PublicClientViewPage() {
         {view.snags && view.snags.length > 0 && (
           <section>
             <h2 className="text-lg font-semibold mb-3">Outstanding items</h2>
-            <Card className="dashboard-card divide-y divide-white/8">
+            <Card className="dashboard-card divide-y divide-hairline">
               {view.snags.map((s) => (
                 <div key={s.id} className="flex items-start gap-3 p-4">
                   <div className="min-w-0 flex-1">

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -395,7 +395,7 @@ export const PublicProfilePage: React.FC = () => {
         style={{ background: 'var(--brand-gradient)' }}
       >
         <div className="absolute -top-12 -left-12 w-72 h-72 rounded-full bg-white/10 blur-3xl pointer-events-none" />
-        <div className="absolute -bottom-10 right-1/3 w-80 h-80 rounded-full bg-white/8 blur-3xl pointer-events-none" />
+        <div className="absolute -bottom-10 right-1/3 w-80 h-80 rounded-full bg-surface-hover blur-3xl pointer-events-none" />
         <div className="absolute top-8 right-16 w-40 h-40 rounded-full bg-accent/20 blur-2xl pointer-events-none" />
       </div>
 

--- a/src/pages/SupplierPortalPage.tsx
+++ b/src/pages/SupplierPortalPage.tsx
@@ -84,7 +84,7 @@ export default function SupplierPortalPage({ embedded = false }: { embedded?: bo
       ) : (
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-primary/12 border border-primary/20 flex items-center justify-center shrink-0">
+            <div className="w-10 h-10 rounded-xl bg-primary/[0.12] border border-primary/20 flex items-center justify-center shrink-0">
               <Inbox className="h-5 w-5 text-primary" />
             </div>
             <div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -87,11 +87,48 @@ export default {
 					DEFAULT: 'hsl(var(--info))',
 					foreground: 'hsl(var(--info-foreground))',
 				},
+				// Surface system. `hairline` is the single rule/edge colour —
+				// header underlines, row separators, panel borders, input outlines
+				// are ALL this one value, which is most of what makes a dense
+				// interface read as tidy rather than busy.
+				hairline: 'hsl(var(--hairline))',
+				surface: {
+					hover: 'hsl(var(--surface-hover))',
+					sunken: 'hsl(var(--surface-sunken))',
+				},
 			},
+			// Product-UI corner scale. `xl`/`2xl`/`3xl` are OVERRIDDEN (Tailwind
+			// ships 12/16/24px) because they are used on hundreds of containers
+			// across the app and the old values rounded a data panel harder than
+			// an OS window. Redefining them here re-shapes every one of those call
+			// sites at once instead of editing them; the names still read as "a
+			// step rounder than the last", which is all a consumer needs.
 			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)',
+				xs: 'var(--radius-xs)',   // 2px  — tag, checkbox
+				sm: 'var(--radius-sm)',   // 4px  — button, input, select, tag
+				DEFAULT: 'var(--radius-sm)',
+				md: 'var(--radius-md)',   // 6px  — card, panel, table container
+				lg: 'var(--radius-md)',   // 6px  — `rounded-lg` is the app's most-used
+				                          //        container radius; it maps to panel.
+				xl: 'var(--radius-lg)',   // 8px  — dialog, popover, dropdown
+				'2xl': 'var(--radius-xl)',// 10px — modal, sheet
+				'3xl': 'var(--radius-2xl)',// 12px — full-bleed hero panel
+			},
+			// Elevation is a ladder with four rungs and a hard ceiling. `xl` and
+			// `2xl` are overridden rather than left at Tailwind's defaults so that
+			// the ~12 call sites reaching for a dramatic shadow land on the same
+			// overlay value everything else floats at — the alternative is one
+			// modal in the app casting a 25px-blur shadow nothing else casts.
+			boxShadow: {
+				xs: 'var(--shadow-xs)',
+				sm: 'var(--shadow-sm)',
+				DEFAULT: 'var(--shadow)',
+				md: 'var(--shadow-md)',
+				lg: 'var(--shadow-lg)',
+				xl: 'var(--shadow-overlay)',
+				'2xl': 'var(--shadow-overlay)',
+				// Floating layers only — dropdown, popover, dialog, toast.
+				overlay: 'var(--shadow-overlay)',
 			},
 			keyframes: {
 				'accordion-down': {

--- a/tests/unit/designSystem.test.ts
+++ b/tests/unit/designSystem.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Guards the design system against the four ways it can be undone WITHOUT anything failing.
+ *
+ * A visual regression is not a type error and not a test failure; it ships, and it is noticed
+ * weeks later by somebody who assumes it was always like that. So this file does not try to
+ * police taste. It pins only the things that (a) silently revert a deliberate decision, or
+ * (b) compile to nothing at all — which is worse, because the class LOOKS right in the source.
+ *
+ * The four:
+ *
+ *   1. An off-scale opacity modifier (`bg-white/8`, `border-white/12`). Tailwind only generates
+ *      opacity variants for steps in `theme.opacity` (0,5,10,…,100). Anything else produces NO
+ *      CSS RULE. The platform had 74 of them: 31 `border-white/8` borders that have never once
+ *      been drawn in dark mode, plus 25 `divide-white/8` row separators in the same state. They
+ *      read as intentional in every code review and were invisible in the product.
+ *
+ *   2. A theme block that forgets a surface token. `hsl(var(--hairline))` with `--hairline`
+ *      undefined is an INVALID color, so the declaration is dropped and the border vanishes —
+ *      in that theme only. Nothing errors, and whoever added the theme is unlikely to be the
+ *      person who notices.
+ *
+ *   3. Reintroducing the global font-weight override. `.font-bold { font-weight: 300 !important }`
+ *      and friends flattened every weight utility in the app to one value, so hierarchy was
+ *      impossible to express and every attempt to fix a specific component silently failed.
+ *
+ *   4. Rolling a primitive back to the marketing language — pill buttons, filled-pill tabs, a
+ *      glass card. These are one-line edits with app-wide consequences.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+import { blankComments, stripComments } from '../helpers/stripComments';
+
+const ROOT = process.cwd();
+const SRC = join(ROOT, 'src');
+const CSS = join(SRC, 'index.css');
+const UI = join(SRC, 'components', 'core', 'ui');
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (p.endsWith('.tsx') || p.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+const rel = (p: string) => relative(ROOT, p).split('\\').join('/');
+
+/** Tailwind 3.4's default `theme.opacity` keys. Anything else needs `/[0.08]` syntax. */
+const OPACITY_SCALE = new Set(
+  [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100].map(String),
+);
+
+/**
+ * Matches `<utility>-<color>/<n>`, requiring the segment immediately before the slash to START
+ * WITH A LETTER. That is what keeps Tailwind's fraction utilities out of the results:
+ * `slide-out-to-left-1/2` ends in `1`, so it is not a colour-with-opacity.
+ */
+const OPACITY_RE =
+  /\b(?:bg|text|border|ring|fill|stroke|outline|divide|placeholder|decoration|accent|caret|from|via|to)-(?:[a-zA-Z][a-zA-Z0-9]*-)*[a-zA-Z][a-zA-Z0-9]*\/(\d{1,3})\b/g;
+
+describe('design system — opacity modifiers that compile to nothing', () => {
+  it('every colour/opacity utility in src/ uses a step Tailwind actually generates', () => {
+    const offenders: string[] = [];
+    for (const f of walk(SRC)) {
+      // blankComments, not stripComments: the reported line number has to point at the real
+      // line in the file, and a prose mention of `border-white/12` in a doc comment explaining
+      // why it was removed must not convict the file that removed it.
+      const src = blankComments(readFileSync(f, 'utf8'));
+      for (const m of src.matchAll(OPACITY_RE)) {
+        if (OPACITY_SCALE.has(m[1])) continue;
+        const line = src.slice(0, m.index).split('\n').length;
+        offenders.push(`${rel(f)}:${line}  ${m[0]}`);
+      }
+    }
+    expect(
+      offenders,
+      'These utilities produce NO CSS. Tailwind only emits an opacity variant for a step in ' +
+        'theme.opacity (0,5,10,...,100); anything else is dropped silently, so the border/fill ' +
+        'you wrote has never rendered. Use a design token (border-hairline, bg-surface-hover, ' +
+        'bg-surface-sunken) or arbitrary-value syntax (bg-primary/[0.08]).\n' +
+        offenders.join('\n'),
+    ).toEqual([]);
+  });
+});
+
+describe('design system — every theme defines every surface token', () => {
+  const css = readFileSync(CSS, 'utf8');
+
+  /** Extracts the declaration body of a top-level rule whose selector text matches. */
+  function block(selectorIncludes: string): string {
+    const idx = css.indexOf(selectorIncludes);
+    expect(idx, `theme block "${selectorIncludes}" is missing from src/index.css`).toBeGreaterThan(
+      -1,
+    );
+    const open = css.indexOf('{', idx);
+    let depth = 0;
+    for (let i = open; i < css.length; i++) {
+      if (css[i] === '{') depth++;
+      else if (css[i] === '}') {
+        depth--;
+        if (depth === 0) return css.slice(open, i);
+      }
+    }
+    return '';
+  }
+
+  // The base blocks must define the whole surface vocabulary. The accent blocks only override
+  // what differs from their mode, so they are checked separately and more narrowly.
+  const BASE_BLOCKS = [':root {', 'html.light {'];
+  const SURFACE_TOKENS = [
+    '--hairline',
+    '--surface-hover',
+    '--surface-sunken',
+    '--card',
+    '--background',
+    '--primary',
+    '--glass-background',
+    '--shadow-overlay',
+  ];
+
+  for (const sel of BASE_BLOCKS) {
+    it(`${sel.trim()} defines the full surface vocabulary`, () => {
+      const body = block(sel);
+      const missing = SURFACE_TOKENS.filter((t) => !body.includes(`${t}:`));
+      expect(
+        missing,
+        `${sel} is missing ${missing.join(', ')}. A token referenced as hsl(var(--x)) with --x ` +
+          'undefined is an invalid colour: the declaration is dropped and the border/fill ' +
+          'disappears in that theme only, with nothing raised anywhere.',
+      ).toEqual([]);
+    });
+  }
+
+  // An accent block that restyles the neutral surfaces (it overrides --card and --border) must
+  // also carry --hairline, or every rule in the app keeps the OTHER accent's edge colour.
+  for (const sel of ["html.light[data-accent='blue'] {", "html.dark[data-accent='blue'] {"]) {
+    it(`${sel.trim()} retints the hairline along with the surfaces`, () => {
+      const body = block(sel);
+      expect(
+        body.includes('--hairline:'),
+        `${sel} overrides the neutral surfaces but not --hairline, so every border in the app ` +
+          'keeps the base accent\'s edge colour on a differently-tinted surface.',
+      ).toBe(true);
+    });
+  }
+});
+
+describe('design system — the global font-weight override stays deleted', () => {
+  const css = readFileSync(CSS, 'utf8');
+
+  it('no weight utility is redefined globally', () => {
+    // `.font-bold { font-weight: … }` etc. — in any order, with or without !important.
+    const re =
+      /\.font-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black)\s*\{[^}]*font-weight[^}]*\}/g;
+    const hits = [...css.matchAll(re)].map((m) => m[0].replace(/\s+/g, ' ').slice(0, 90));
+    expect(
+      hits,
+      'A global weight override is back. It flattens every weight utility across the whole app ' +
+        '(a table header, a total and its caption all render identically) and it cannot be ' +
+        'worked around per component, because it carried !important. Change the component ' +
+        'instead.\n' + hits.join('\n'),
+    ).toEqual([]);
+  });
+});
+
+describe('design system — primitives keep their product-UI shape', () => {
+  // Comments stripped: several of these files DOCUMENT the pattern they no longer use,
+  // and a guard that convicts a file for explaining itself teaches people to stop explaining.
+  const read = (f: string) => stripComments(readFileSync(join(UI, f), 'utf8'));
+
+  it('buttons are rectangular and do not move on hover', () => {
+    const src = read('button.tsx');
+    expect(src, 'a pill button is the same silhouette as a status chip and an active tab').not.toMatch(
+      /rounded-full/,
+    );
+    expect(
+      src,
+      'hover:-translate-y moves the target out from under the pointer and shoves the whole row',
+    ).not.toMatch(/hover:-?translate-y/);
+  });
+
+  it('the active tab is an underline, not a filled pill', () => {
+    const src = read('tabs.tsx');
+    expect(
+      src,
+      'data-[state=active]:bg-primary paints the active tab as a solid accent block — which is ' +
+        'exactly what a primary button looks like. The underline treatment lives in index.css ' +
+        'on [role="tab"].',
+    ).not.toMatch(/data-\[state=active\]:bg-primary/);
+  });
+
+  it('the card is an opaque panel, not glass', () => {
+    const src = read('card.tsx');
+    expect(src, 'backdrop blur on a panel: no fixed contrast ratio, and a compositor pass per panel')
+      .not.toMatch(/backdropFilter|backdrop-blur/);
+    expect(src, 'a resting panel is separated by a hairline, not by a shadow').not.toMatch(
+      /shadow-(?:md|lg|xl|2xl)/,
+    );
+  });
+
+  it('the checkbox distinguishes indeterminate from checked', () => {
+    const src = read('checkbox.tsx');
+    expect(
+      src.includes("props.checked === 'indeterminate'"),
+      'Radix renders Indicator for both checked and indeterminate. Without a separate glyph, ' +
+        '"some rows selected" is drawn identically to "all rows selected" — which is the whole ' +
+        'question immediately before a bulk delete.',
+    ).toBe(true);
+  });
+});
+
+describe('design system — the app canvas stays flat', () => {
+  it('Layout renders no aurora or grain layer', () => {
+    const layout = stripComments(
+      readFileSync(join(SRC, 'components', 'core', 'Layout.tsx'), 'utf8'),
+    );
+    expect(
+      /<div className="app-(?:aurora|grain)"/.test(layout),
+      'A gradient/texture canvas behind every page means an opaque panel can never match the ' +
+        'ground and every chart loses contrast against a moving background.',
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
@
Rebuilds the visual language of the platform onto a **product-UI** system modelled on the HubSpot
screenshots — flat opaque surfaces, hairline separation, dense controls, underline tabs, one accent.

**Kept exactly as-is, as asked:** the colour system (dark/light × green/blue accents), the header
menu, and the apps mega-menu. Only the nav items' *state* treatment moved onto the system (an active
item is a tinted item with accent text rather than a solid accent pill — same rule as tabs).

## Why each change, not just what

| Change | What the old version cost |
|---|---|
| Glass → opaque panels | A translucent panel has no fixed contrast ratio. Table-row legibility depended on what scrolled underneath, so the same content was compliant in one scroll position and marginal in another — and no static audit can see that. Plus a live `backdrop-filter` per panel. |
| Aurora canvas → flat `--background` | An opaque panel can only match a flat ground, and every chart/KPI/table lost contrast against a moving gradient. `background-attachment: fixed` also repainted the viewport every scroll frame. |
| Filled-pill tabs → underline tabs | A filled accent pill is the exact silhouette of a primary button. On every record page, "the section you are in" and "the button to press" were the same object. |
| Pill buttons → 4px rectangles, 36px | Buttons, status chips, filter chips and active tabs were all pills — a toolbar had no readable grammar. And `hover:-translate-y` moved the target out from under the pointer. |
| Global weight override deleted | `.font-bold → 300 !important` and friends flattened every weight utility, so a table header, a total, a KPI and its caption rendered identically — and no component could opt out. |

## Migration is by token, not by sweep

The `--glass-*` variables kept their names and were repointed at opaque values, so **~400 call sites
of `.dashboard-card` changed material without being edited**. `.glass-panel`, `.gradient-border`,
`.tinted-card`, `.tabs-underline`, `.glow-*`, `.app-aurora` and `.app-grain` all still resolve — as
the new thing, or as an inert no-op. Nothing needs a find-and-replace to keep compiling.

## A real bug the new system exposed

74 off-scale opacity utilities (`border-white/8`, `divide-white/8`, `border-white/12`, …). Tailwind
only emits opacity variants for steps in `theme.opacity`, so **these produced no CSS at all** — 31
borders and 25 row dividers that have never once rendered in dark mode. They looked deliberate in
every code review. All replaced with tokens, and a guard now fails the build on a new one.

## What is new

- **`src/components/core/hub/`** — the pattern library the primitives compose into. `HubDataTable`
  (selection, sorting, skeleton rows, empty state, footer band), `HubToolbar` + `HubFilterSelect`,
  `HubRecordLayout` + `HubPanel` + `HubProperty`, `HubTimeline`, `HubStatTile`/`HubStatGrid`,
  `HubSideNav`, `HubTabNav`, `HubEmptyState`.
- **`/design-system`** — a live specimen sheet with a light/dark × green/blue switcher, showing the
  three screen archetypes (list, record, settings) built from the real components. The one thing a
  screenshot cannot tell you is whether a surface survives all four theme combinations.
- **`docs/design-system.md`** — the full reference, moved out of the gitignored `.claude/` so it can
  be reviewed in a PR and reverted with the change it describes.
- **`tests/unit/designSystem.test.ts`** — guards the four ways this can be undone with nothing
  failing: an off-scale opacity modifier; a theme block missing a surface token (an undefined var is
  an *invalid colour*, so the border silently vanishes in that theme only); a reinstated weight
  override; a primitive rolled back to pills/glass. Each was verified to actually fire.

## Verification

`npm run lint` · `npm run typecheck` · `npm test` — all green (141 files, 1913 tests).
Rendered and checked in all four theme combinations at `/design-system`, plus `/tools` and
`/changelog` as real pages.

## Reverting

Single commit on `design/hubspot-system`. Revert it and every token, primitive and doc goes back
together — the new `hub/` components and the specimen page are additive and unreferenced elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@